### PR TITLE
add 404 and draft docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ By default, all CSS you include with Webpack (via `require` or `import`) will be
 During the static build, each page has the CSS relevant to it injected inline, and the complete stylesheet is loaded lazily, after the rest of the page is rendered.
 Sometimes, however, you want to include CSS that will *never* be used on other pages, so you don't want it to be included in the complete stylesheet.
 
-To do that, create CSS files *within the [`pagesDirectory`] — preferably adjacent to the page that uses them.
+To do that, create CSS files within the [`pagesDirectory`] — preferably adjacent to the page that uses them.
 Import a page-specific CSS from the page that will use it.
 It exports a React component that you should render in your page. For example:
 
@@ -247,7 +247,7 @@ class MyPage extends React.Component {
 ### Prefixing URLs
 
 During Webpack compilation, Batfish exposes the module `batfish/prefix-url`.
-Use this to prefix your URLs according to the [`siteBasePath`] and [`siteOrigin`] you specified in your b, ensuring that they point to the right place both during development and in production.
+Use this to prefix your URLs according to the [`siteBasePath`] and [`siteOrigin`] you specified in your configuration, ensuring that they point to the right place both during development and in production.
 
 ```js
 // Let's imagine:

--- a/README.md
+++ b/README.md
@@ -164,11 +164,17 @@ class MyPage extends React.PureComponent {
 }
 ```
 
+### Path not found: 404
+
+It is optional to create a 404 page. If you want to create your own, add a `404.js` to `/pages`.
+
+In development, you can expect to test and see your 404 page by entering an invalid path. Locally if you run `serve-static`, expect to see `Cannot GET /yourInvalidPathHere`. In [`production`], your 404 page will need to be handled and rendered by the server.
+
 ### Draft pages
 
 Any page with `published: false` in its front matter will be considered a draft page.
 
-Draft pages are built during development but are *not* included in [`production`] builds.
+In development, draft pages are built and visible. However, in [`production`], these pages are **not** included in builds and should be handled with a 404 by the server.
 
 ### Page-specific CSS
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ class MyPage extends React.PureComponent {
 
 ### Path not found: 404
 
-It is optional to create a 404 page. If you want to create your own, add a `404.js` to `/pages`.
+Note that adding the `notFoundPath` property is optional in your `batfish.config.js`. By default, it looks for a `404.js` in your directory. If you provide `notFoundPath` a valid string path, the 404s will point to this absolute path.
 
 In development, you can expect to test and see your 404 page by entering an invalid path. Locally if you run `serve-static`, expect to see `Cannot GET /yourInvalidPathHere`. In [`production`], your 404 page will need to be handled and rendered by the server.
 

--- a/conf/eslint-base.json
+++ b/conf/eslint-base.json
@@ -24,6 +24,6 @@
     "strict": ["off"],
     "valid-typeof": ["error"],
 
-    "filenames/match-regex": ["error", "^[a-z-\\.]+?$"]
+    "filenames/match-regex": ["error", "^[0-9a-z-\\.]+?$"]
   }
 }


### PR DESCRIPTION
Closes https://github.com/mapbox/batfish/issues/55 and https://github.com/mapbox/batfish/issues/54.

Initially, implementing draft pages and 404s wasn't obvious to me, so I updated the docs, but I'm open to improving the wording more.