### PR TITLE
Allow page filenames to be 404

### DIFF
--- a/conf/eslint-base.json
+++ b/conf/eslint-base.json
@@ -24,6 +24,6 @@
     "strict": ["off"],
     "valid-typeof": ["error"],
 
-    "filenames/match-regex": ["error", "^[a-z-\\.]+?$"]
+    "filenames/match-regex": ["error", "^[0-9a-z-\\.]+?$"]
   }
 }


### PR DESCRIPTION
This PR is meant to allow for pages to be named `404.*`, the default "route not found" page.