### PR TITLE
Add siteOrigin example

### DIFF
--- a/examples/using-siteOrigin/batfish.config.js
+++ b/examples/using-siteOrigin/batfish.config.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const path = require('path');
+
+module.exports = () => {
+  return {
+    externalStylesheets: [
+      'https://api.mapbox.com/mapbox-assembly/v0.13.0/assembly.min.css'
+    ],
+    siteOrigin: '//localhost:8080',
+    wrapperPath: path.join(__dirname, './src/components/wrapper.js')
+  };
+};

--- a/examples/using-siteOrigin/package.json
+++ b/examples/using-siteOrigin/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "scripts": {
+    "batfish": "../../bin/batfish.js"
+  },
+  "dependencies": {}
+}

--- a/examples/using-siteOrigin/src/components/wrapper.js
+++ b/examples/using-siteOrigin/src/components/wrapper.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const React = require('react');
+const prefixUrl = require('batfish/prefix-url');
+
+require('../wrapper.css');
+
+class Wrapper extends React.Component {
+  render() {
+    return (
+      <div className="page-wrapper flex-parent flex-parent--stretch-cross hfull p24">
+        <div className="sidebar p24 bg-gray-faint">
+          <p className="txt-xs txt-uppercase">
+            <strong>Menu</strong>
+          </p>
+          <nav className="nav mb12">
+            <ul>
+              <li className="nav__item">
+                <a className="link" href={prefixUrl.absolute('/')}>
+                  Home
+                </a>
+              </li>
+              <li className="nav__item">
+                <a className="link" href={prefixUrl.absolute('/page-a')}>
+                  Page A
+                </a>
+              </li>
+              <li className="nav__item">
+                <a className="link" href={prefixUrl.absolute('/page-b')}>
+                  Page B
+                </a>
+              </li>
+            </ul>
+          </nav>
+          <p className="txt-s mb6">
+            The links above are absolute URLs, created using{' '}
+            <code>prefixUrl.absolute</code>.
+          </p>
+          <p className="txt-s">Neat!</p>
+        </div>
+        <div className="main-content p24">
+          {this.props.children}
+        </div>
+      </div>
+    );
+  }
+}
+
+module.exports = Wrapper;

--- a/examples/using-siteOrigin/src/pages/404.js
+++ b/examples/using-siteOrigin/src/pages/404.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const React = require('react');
+const prefixUrl = require('batfish/prefix-url');
+
+class NotFound extends React.PureComponent {
+  render() {
+    return (
+      <div>
+        Oops, this is not a page.{' '}
+        <a href={prefixUrl('/')} className="link">
+          Go home.
+        </a>
+      </div>
+    );
+  }
+}
+
+module.exports = NotFound;

--- a/examples/using-siteOrigin/src/pages/index.js
+++ b/examples/using-siteOrigin/src/pages/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const React = require('react');
+
+class Index extends React.Component {
+  render() {
+    return <div>I am the index page.</div>;
+  }
+}
+
+module.exports = Index;

--- a/examples/using-siteOrigin/src/pages/page-a.js
+++ b/examples/using-siteOrigin/src/pages/page-a.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const React = require('react');
+
+class PageA extends React.Component {
+  render() {
+    return <div>I am Page A.</div>;
+  }
+}
+
+module.exports = PageA;

--- a/examples/using-siteOrigin/src/pages/page-b.js
+++ b/examples/using-siteOrigin/src/pages/page-b.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const React = require('react');
+
+class PageB extends React.Component {
+  render() {
+    return <div>I am Page B.</div>;
+  }
+}
+
+module.exports = PageB;

--- a/examples/using-siteOrigin/src/wrapper.css
+++ b/examples/using-siteOrigin/src/wrapper.css
@@ -1,0 +1,11 @@
+body,
+#batfish-content,
+.page-wrapper {
+  height: 100vh;
+}
+
+.sidebar {
+  overflow-x: hidden;
+  overflow-y: auto;
+  width: 270px;
+}


### PR DESCRIPTION
This PR adds an example of `siteOrigin`.

I'm not sure if this is the best example (using `//localhost:8080`), but I couldn't think of anything better that would allow us to use `siteOrigin` in the routes. Any ideas?