### PR TITLE
Add inline-js example and recipes docs

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,0 +1,45 @@
+# Recipes
+
+How to do some things that you might want to do and might not know how to do.
+
+## Inject JS onto the page with an inline `<script>` tag
+
+You can just use [react-helmet]!
+
+Keep in mind that the code will need to be a string.
+
+```jsx
+class MyPage extends React.Component {
+  return (
+    <div>
+      <Helmet>
+        <script>{'console.log("this will log")'}</script>
+      </Helmet>
+    </div>
+  )
+}
+```
+
+If you follow this pattern, your `<script>` tag will appear in the document's `<head>` both in the development server and in the static HTML.
+
+Maybe you have your code in its own file and want to keep it there and load it from there, instead of pasting it as a string in a React component.
+This can be done by using Webpack's [raw-loader] to import the source file as a string.
+
+```jsx
+const mySpecialScript = require('raw-loader!../js/my-special-script.js');
+class MyPage extends React.Component {
+  return (
+    <div>
+      <Helmet>
+        <script>{mySpecialScript}</script>
+      </Helmet>
+    </div>
+  )
+}
+```
+
+You can also use the [`webpackLoaders`] option in your Batfish configuration to avoid the Webpack-specific `require('raw-loader!'..)` syntax.
+
+[react-helmet]: https://github.com/nfl/react-helmet
+[raw-loader]: https://github.com/webpack-contrib/raw-loader
+[`webpackLoaders`]: configuration.md#webpackloaders

--- a/examples/inline-js/batfish.config.js
+++ b/examples/inline-js/batfish.config.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const path = require('path');
+
+module.exports = () => {
+  return {
+    wrapperPath: path.join(__dirname, './src/components/wrapper.js'),
+    siteOrigin: 'https://www.mapbox.com'
+  };
+};

--- a/examples/inline-js/package.json
+++ b/examples/inline-js/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "scripts": {
+    "batfish": "../../bin/batfish.js"
+  },
+  "dependencies": {
+    "raw-loader": "^0.5.1"
+  }
+}

--- a/examples/inline-js/src/components/wrapper.js
+++ b/examples/inline-js/src/components/wrapper.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const React = require('react');
+const Helmet = require('react-helmet').Helmet;
+
+class Wrapper extends React.Component {
+  render() {
+    return (
+      <div>
+        <Helmet>
+          <script>
+            {"console.log('the wrapper has rendered')"}
+          </script>
+        </Helmet>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+module.exports = Wrapper;

--- a/examples/inline-js/src/js/inline-me.js
+++ b/examples/inline-js/src/js/inline-me.js
@@ -1,0 +1,1 @@
+console.log('inline-me.js has been executed');

--- a/examples/inline-js/src/pages/index.js
+++ b/examples/inline-js/src/pages/index.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const React = require('react');
+const Helmet = require('react-helmet').Helmet;
+const inlineMe = require('raw-loader!../js/inline-me');
+
+class Home extends React.Component {
+  render() {
+    return (
+      <div>
+        <Helmet>
+          <script>
+            {"console.log('the home page has rendered')"}
+          </script>
+          <script>
+            {inlineMe}
+          </script>
+        </Helmet>
+        here's some regular content
+      </div>
+    );
+  }
+}
+
+module.exports = Home;


### PR DESCRIPTION
Closes #65.

Because injecting inline JS can be done without additional configuration *but it might not be obvious to a user*, I thought we could add a recipes doc to explain patterns like this.

@lshig for review.