### PR TITLE
Handle unspecified siteOrigin

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -119,8 +119,12 @@ function build(rawConfig, projectDirectory) {
         });
     })
     .then(() => {
-      timelog('Building the sitemap');
-      return generateSitemap(batfishConfig);
+      if (batfishConfig.siteOrigin) {
+        timelog('Building the sitemap');
+        return generateSitemap(batfishConfig);
+      } else {
+        timelog('siteOrigin is not specified, unable to generate sitemap');
+      }
     })
     .then(() => {
       timelog('Successful static HTML build');

--- a/lib/create-prefix-url.js
+++ b/lib/create-prefix-url.js
@@ -22,6 +22,10 @@ function createPrefixUrl(batfishConfig) {
       return '${batfishConfig.siteBasePath}' + url;
     }
     prefixUrl.absolute = url => {
+      if (${!batfishConfig.siteOrigin}) {
+        throw new Error('siteOrigin is not specified. Unable to prefix with absolute path.');
+      }
+
       return '${batfishConfig.siteOrigin}' + '${batfishConfig.siteBasePath}' + url;
     };
     module.exports = prefixUrl;

--- a/lib/generate-sitemap.js
+++ b/lib/generate-sitemap.js
@@ -16,18 +16,17 @@ function generateSitemap(batfishConfig) {
     path.join(batfishConfig.outputDirectory, 'sitemap.xml')
   );
   return new Promise((resolve, reject) => {
-    sitemapStatic(
-      sitemapWriter,
-      {
+    try {
+      sitemapStatic(sitemapWriter, {
         findRoot: batfishConfig.outputDirectory,
         prefix: batfishConfig.siteOrigin + batfishConfig.siteBasePath,
         pretty: true
-      },
-      error => {
-        if (error) return reject(error);
-        resolve();
-      }
-    );
+      });
+
+      resolve();
+    } catch (error) {
+      reject(error);
+    }
   });
 }
 

--- a/lib/generate-sitemap.js
+++ b/lib/generate-sitemap.js
@@ -16,17 +16,14 @@ function generateSitemap(batfishConfig) {
     path.join(batfishConfig.outputDirectory, 'sitemap.xml')
   );
   return new Promise((resolve, reject) => {
-    try {
-      sitemapStatic(sitemapWriter, {
-        findRoot: batfishConfig.outputDirectory,
-        prefix: batfishConfig.siteOrigin + batfishConfig.siteBasePath,
-        pretty: true
-      });
+    sitemapWriter.on('error', reject);
+    sitemapWriter.on('finish', resolve);
 
-      resolve();
-    } catch (error) {
-      reject(error);
-    }
+    sitemapStatic(sitemapWriter, {
+      findRoot: batfishConfig.outputDirectory,
+      prefix: batfishConfig.siteOrigin + batfishConfig.siteBasePath,
+      pretty: true
+    });
   });
 }
 

--- a/lib/generate-sitemap.js
+++ b/lib/generate-sitemap.js
@@ -17,7 +17,7 @@ function generateSitemap(batfishConfig) {
   );
   return new Promise((resolve, reject) => {
     sitemapWriter.on('error', reject);
-    sitemapWriter.on('finish', resolve);
+    sitemapWriter.on('finish', () => resolve());
 
     sitemapStatic(sitemapWriter, {
       findRoot: batfishConfig.outputDirectory,


### PR DESCRIPTION
If a user doesn't specify `siteOrigin`, then Batfish will now do the following:
* Throw an error when using `prefixUrl.absolute`
* Skip sitemap generation and display an explanatory message

I also modified `lib/generate-sitemap.js`. I added a try/catch block to fix promise resolution, because it turns out the `sitemap-static` package doesn't accept a callback ([check out the function](https://github.com/tmcw/sitemap-static/blob/master/index.js#L17)).

Closes #43 

@davidtheclark 👀  