### PR TITLE
add transform-react-remove-prop-types plugin for production builds

### DIFF
--- a/lib/create-webpack-config-base.js
+++ b/lib/create-webpack-config-base.js
@@ -62,12 +62,7 @@ function createWebpackConfigBase(batfishConfig) {
       ]
     ].concat(batfishConfig.babelPlugins || []);
     if (batfishConfig.production) {
-      babelPlugins.push([
-        'transform-react-remove-prop-types',
-        {
-          ignoreFilenames: ['node_modules']
-        }
-      ]);
+      babelPlugins.push('transform-react-remove-prop-types');
     } else {
       babelPlugins.push('transform-react-jsx-source');
       babelPlugins.push('transform-react-jsx-self');

--- a/lib/create-webpack-config-base.js
+++ b/lib/create-webpack-config-base.js
@@ -61,8 +61,14 @@ function createWebpackConfigBase(batfishConfig) {
         }
       ]
     ].concat(batfishConfig.babelPlugins || []);
-
-    if (!batfishConfig.production) {
+    if (batfishConfig.production) {
+      babelPlugins.push([
+        'transform-react-remove-prop-types',
+        {
+          ignoreFilenames: ['node_modules']
+        }
+      ]);
+    } else {
       babelPlugins.push('transform-react-jsx-source');
       babelPlugins.push('transform-react-jsx-self');
     }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-react-jsx-self": "^6.22.0",
     "babel-plugin-transform-react-jsx-source": "^6.22.0",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.6",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -772,6 +772,12 @@ babel-plugin-transform-react-jsx@^6.24.1:
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-react-remove-prop-types@^0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.6.tgz#c3d20ff4e97fb08fa63e86a97b2daab6ad365a19"
+  dependencies:
+    babel-traverse "^6.24.1"
+
 babel-plugin-transform-regenerator@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz#b8da305ad43c3c99b4848e4fe4037b770d23c418"


### PR DESCRIPTION
Closes https://github.com/mapbox/batfish/issues/82.

Documentation for the plugin is here: https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types.

Followed documentation for "Via Node API". By default, the `mode` option is `'remove'` so it wasn't included in `create-webpack-config-base.js`.

I tested this plugin by looking at `examples/appropriate-images` in production (build and serve-static). The plugin removes propTypes from JavaScript files, but they are still present in the `source-map` files that are generated by the devtools option. See the following images:

Before plugin added:
<img width="914" alt="screen shot 2017-07-16 at 6 32 14 pm" src="https://user-images.githubusercontent.com/9087698/28279124-57395510-6ad4-11e7-8cbb-c3b5e97a6614.png">

After plugin added:
<img width="916" alt="screen shot 2017-07-16 at 6 33 50 pm" src="https://user-images.githubusercontent.com/9087698/28279143-63212cc2-6ad4-11e7-9ec5-65afb941714d.png">
