### PR TITLE
add invalid property error

### DIFF
--- a/lib/validate-config.js
+++ b/lib/validate-config.js
@@ -5,6 +5,37 @@ const del = require('del');
 const path = require('path');
 const mkdirp = require('mkdirp');
 
+/*
+* Whenever you add a new configuration property,
+* you'll need to add it to the following list!
+*/
+const validConfigProperties = [
+  'siteBasePath',
+  'siteOrigin',
+  'wrapperPath',
+  'notFoundPath',
+  'externalStylesheets',
+  'autoprefixerBrowsers',
+  'pagesDirectory',
+  'staticDirectory',
+  'outputDirectory',
+  'temporaryDirectory',
+  'data',
+  'dataSelectors',
+  'vendorModules',
+  'webpackLoaders',
+  'webpackPlugins',
+  'babelPlugins',
+  'babelExclude',
+  'postcssPlugins',
+  'fileLoaderExtensions',
+  'jsxtremeMarkdownOptions',
+  'inlineJs',
+  'production',
+  'port',
+  'verbose'
+];
+
 /**
  * Add defaults to a raw config object, and validate it.
  * All options and defaults are documented in the README.
@@ -57,33 +88,6 @@ function validateConfig(config, configPath) {
   }
 
   const configWithDefaults = Object.assign({}, defaults, config);
-
-  const validConfigProperties = [
-    'siteBasePath',
-    'siteOrigin',
-    'wrapperPath',
-    'notFoundPath',
-    'externalStylesheets',
-    'autoprefixerBrowsers',
-    'pagesDirectory',
-    'staticDirectory',
-    'outputDirectory',
-    'temporaryDirectory',
-    'data',
-    'dataSelectors',
-    'vendorModules',
-    'webpackLoaders',
-    'webpackPlugins',
-    'babelPlugins',
-    'babelExclude',
-    'postcssPlugins',
-    'fileLoaderExtensions',
-    'jsxtremeMarkdownOptions',
-    'inlineJs',
-    'production',
-    'port',
-    'verbose'
-  ];
 
   const configWithDefaultsProperties = Object.keys(configWithDefaults);
 

--- a/lib/validate-config.js
+++ b/lib/validate-config.js
@@ -58,6 +58,51 @@ function validateConfig(config, configPath) {
 
   const configWithDefaults = Object.assign({}, defaults, config);
 
+  const validConfigProperties = [
+    'verbose',
+    'pagesDirectory',
+    'staticDirectory',
+    'outputDirectory',
+    'siteBasePath',
+    'siteOrigin',
+    'wrapperPath',
+    'notFoundPath',
+    'temporaryDirectory',
+    'data',
+    'dataSelectors',
+    'vendorModules',
+    'webpackLoaders',
+    'webpackPlugins',
+    'babelPlugins',
+    'babelExclude',
+    'externalStylesheets',
+    'autoprefixerBrowsers',
+    'postcssPlugins',
+    'fileLoaderExtensions',
+    'jsxtremeMarkdownOptions',
+    'inlineJs',
+    'production',
+    'port'
+  ];
+
+  const configWithDefaultsProperties = Object.keys(configWithDefaults);
+
+  const invalidProperties = _.pullAll(
+    configWithDefaultsProperties,
+    validConfigProperties
+  );
+
+  if (invalidProperties.length > 0) {
+    if (invalidProperties.length === 1) {
+      throw new Error(
+        invalidProperties.toString() + ' is an invalid config property'
+      );
+    }
+    throw new Error(
+      invalidProperties.join(', ') + ' are invalid config properties'
+    );
+  }
+
   if (!isAbsolutePath(configWithDefaults.pagesDirectory)) {
     throw new Error('pagesDirectory must be an absolute path');
   }

--- a/lib/validate-config.js
+++ b/lib/validate-config.js
@@ -59,14 +59,15 @@ function validateConfig(config, configPath) {
   const configWithDefaults = Object.assign({}, defaults, config);
 
   const validConfigProperties = [
-    'verbose',
-    'pagesDirectory',
-    'staticDirectory',
-    'outputDirectory',
     'siteBasePath',
     'siteOrigin',
     'wrapperPath',
     'notFoundPath',
+    'externalStylesheets',
+    'autoprefixerBrowsers',
+    'pagesDirectory',
+    'staticDirectory',
+    'outputDirectory',
     'temporaryDirectory',
     'data',
     'dataSelectors',
@@ -75,14 +76,13 @@ function validateConfig(config, configPath) {
     'webpackPlugins',
     'babelPlugins',
     'babelExclude',
-    'externalStylesheets',
-    'autoprefixerBrowsers',
     'postcssPlugins',
     'fileLoaderExtensions',
     'jsxtremeMarkdownOptions',
     'inlineJs',
     'production',
-    'port'
+    'port',
+    'verbose'
   ];
 
   const configWithDefaultsProperties = Object.keys(configWithDefaults);

--- a/lib/validate-config.js
+++ b/lib/validate-config.js
@@ -5,10 +5,8 @@ const del = require('del');
 const path = require('path');
 const mkdirp = require('mkdirp');
 
-/*
-* Whenever you add a new configuration property,
-* you'll need to add it to the following list!
-*/
+// !!! Whenever you add a new configuration property,
+// you'll need to add it to the following list
 const validConfigProperties = [
   'siteBasePath',
   'siteOrigin',

--- a/test/validate-config.test.js
+++ b/test/validate-config.test.js
@@ -29,6 +29,24 @@ describe('validateConfig', () => {
     expect(config).toMatchSnapshot();
   });
 
+  test('invalid configuration properties fails', () => {
+    const invalidPropertyConfig = {
+      port: 8080,
+      fakePort: 1337
+    };
+    expect(() => validateConfig(invalidPropertyConfig)).toThrow(
+      'fakePort is an invalid config property'
+    );
+    const invalidPropertiesConfig = {
+      fakeProduction: true,
+      fakePort: 1337,
+      fakeExternalStylesheets: null
+    };
+    expect(() => validateConfig(invalidPropertiesConfig)).toThrow(
+      'fakeProduction, fakePort, fakeExternalStylesheets are invalid config properties'
+    );
+  });
+
   test('temporaryDirectory is created and cleared', () => {
     const result = validateConfig(undefined, projectDirectory);
     expect(mkdirp.sync).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Closes https://github.com/mapbox/batfish/issues/45.

Properties are documented here: https://github.com/mapbox/batfish/blob/master/docs/configuration.md.

Cut a ticket for documentation on `verbose` https://github.com/mapbox/batfish/issues/98

Used existing `lodash` library to compare 2 properties name lists and return the list of properties that don't match.