### PR TITLE
withLocation higher-order component

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -8,6 +8,7 @@
 -   [Routing within a page](#routing-within-a-page)
 -   [Markdown within JS](#markdown-within-js)
 -   [Dynamically changing pages](#dynamically-changing-pages)
+-   [withLocation](#withlocation)
 
 ## Draft pages
 
@@ -170,4 +171,30 @@ routeTo.prefixed('writer');
 
 // Regular link behavior is used, since this is not a page Batfish made
 routeTo('/about/money');
+```
+
+## withLocation
+
+During Webpack compilation, Batfish exposes the module `batfish/with-location`.
+This module exports a higher-order component that you can use to inject an abbreviated [Location](https://developer.mozilla.org/en-US/docs/Web/API/Location) object into the props of your component, containing `pathname`, `hash`, and `search`.
+
+On the initial page load, the value will only include `pathname`.
+As soon as your component mounts, however, it will pick up `hash` and `search`, as well.
+
+```jsx
+const withLocation = require('batfish/with-location');
+
+class MyPage extends React.Component {
+  render() {
+    return (
+      <div>
+        <div>pathname: {this.props.location.pathname}</div>
+        <div>hash: {this.props.location.hash}</div>
+        <div>search: {this.props.location.search}</div>
+      </div>
+    )
+  }
+}
+
+module.exports = withLocation(MyPage);
 ```

--- a/examples/initial-experiments/src/pages/index.js
+++ b/examples/initial-experiments/src/pages/index.js
@@ -8,12 +8,14 @@ siteData:
 'use strict';
 
 const React = require('react');
+const withLocation = require('batfish/with-location');
 const PageShell = require('../components/page-shell');
 
 class Home extends React.Component {
   render() {
     return (
       <PageShell>
+        {JSON.stringify(this.props.location)}
         <div>
           {this.props.frontMatter.title}
         </div>
@@ -40,4 +42,4 @@ class Home extends React.Component {
   }
 }
 
-module.exports = Home;
+module.exports = withLocation(Home);

--- a/lib/create-webpack-config-base.js
+++ b/lib/create-webpack-config-base.js
@@ -130,7 +130,11 @@ function createWebpackConfigBase(batfishConfig) {
           'batfish/context': batfishContextPath,
           'batfish/wrapper': batfishConfig.wrapperPath,
           'batfish/prefix-url': prefixUrlPath,
-          'batfish/route-to': path.join(__dirname, '../src/route-to.js')
+          'batfish/route-to': path.join(__dirname, '../src/route-to.js'),
+          'batfish/with-location': path.join(
+            __dirname,
+            '../src/with-location.js'
+          )
         }
       },
       module: {

--- a/src/with-location.js
+++ b/src/with-location.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const React = require('react');
+const PropTypes = require('prop-types');
+
+function withLocation(Component) {
+  class WithLocation extends React.Component {
+    static contextTypes = {
+      location: PropTypes.shape({
+        pathname: PropTypes.string.isRequired,
+        hash: PropTypes.string,
+        search: PropTypes.string
+      }).isRequired
+    };
+
+    render() {
+      return <Component location={this.context.location} {...this.props} />;
+    }
+  }
+
+  WithLocation.WrapperComponent = Component;
+  return WithLocation;
+}
+
+module.exports = withLocation;


### PR DESCRIPTION
Partially addresses #76.

Adds a `withLocation` higher-order component that you can use to inject an abbreviated Location object into a component's props.