### PR TITLE
Add search and hash to initial location

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -162,9 +162,6 @@ routeTo('/about/money');
 Batfish exposes the module `@mapbox/batfish/modules/with-location`.
 This module exports a higher-order component that you can use to inject an abbreviated [Location](https://developer.mozilla.org/en-US/docs/Web/API/Location) object into the props of your component, containing `pathname`, `hash`, and `search`.
 
-On the initial page load, the value will only include `pathname`.
-As soon as your component mounts, however, it will pick up `hash` and `search`, as well.
-
 ```jsx
 const withLocation = require('@mapbox/batfish/modules/with-location');
 

--- a/examples/initial-experiments/src/pages/index.js
+++ b/examples/initial-experiments/src/pages/index.js
@@ -12,6 +12,9 @@ import { uniqueImport } from '../components/unique-import';
 uniqueImport();
 
 class Home extends React.Component {
+  componentWillMount() {
+    console.log(JSON.stringify(this.props.location));
+  }
   render() {
     return (
       <PageShell>

--- a/src/router.js
+++ b/src/router.js
@@ -33,13 +33,18 @@ class Router extends React.PureComponent {
     super(props);
     this.routeTo = this.routeTo.bind(this);
     this.changePage = this.changePage.bind(this);
+    const location = {
+      pathname: this.props.startingPath
+    };
+    if (typeof window !== 'undefined') {
+      location.search = window.location.search;
+      location.hash = window.location.hash;
+    }
     this.state = {
       path: this.props.startingPath,
       pageComponent: this.props.startingComponent,
       pageProps: this.props.startingProps,
-      location: {
-        pathname: this.props.startingPath
-      }
+      location
     };
   }
 


### PR DESCRIPTION
Closes #113.

Of course there will be no `hash` or `search` during the static build; but now you can expect them to be available even in your component's `componentWillMount` function when that code is running in the browser.

@tristen for review.