### PR TITLE
Prevent scrolling to top under certain conditions

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -90,7 +90,9 @@ class Router extends React.PureComponent {
     }
     this.changePage(targetLocation, {
       pushState: true,
-      scrollToTop: true
+      scrollToTop:
+        window.location.pathname !== targetLocation.pathname ||
+        !targetLocation.hash
     });
   }
 


### PR DESCRIPTION
We don't want to scroll to top when the location's pathname is the exact same or if the hash is not present.