### PR TITLE
Upgrade jsxtreme-markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@ node_modules
 babel-cache
 _batfish_site
 _batfish_tmp
-**/yarn.lock
+**/package-lock.json
 coverage
 modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     They are just HTML pages, e.g. `404.html`.
 -   [Breaking change] Changed default `outputDirectory` from `_site` to `_batfish_site`.
 -   [Breaking change] Changed default `temporaryDirectory` from `_tmp` to `_batfish_tmp`.
+-   [Breaking change] Upgrade jsxtreme-markdown, which changed `modules` front matter property in Markdown pages to `prependJs`.
 
 ## 0.6.0
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Example:
 
 ```md
 ---
-modules:
+prependJs:
   - `import { myDateFormatter } from './path/to/my-date-formatter';
 ---
 

--- a/examples/basic/src/pages/markdown-page.md
+++ b/examples/basic/src/pages/markdown-page.md
@@ -3,7 +3,7 @@ title: Markdown Page
 description: This is a basic Batfish example
 published: true
 summary: This is a Markdown page
-modules:
+prependJs:
   - import PageShell from '../components/page-shell';
 ---
 {{<PageShell

--- a/examples/initial-experiments/src/pages/posts/three.md
+++ b/examples/initial-experiments/src/pages/posts/three.md
@@ -3,7 +3,7 @@ title: Post number 3
 description: blah blah blah
 published: false
 wrapper: "../../components/md-wrapper.js"
-modules:
+prependJs:
   - "import { sharedImport } from '../../components/shared-import';"
 ---
 

--- a/lib/create-webpack-config-base.js
+++ b/lib/create-webpack-config-base.js
@@ -27,11 +27,12 @@ function createWebpackConfigBase(batfishConfig) {
     const jsxtremeMarkdownOptions = _.clone(
       batfishConfig.jsxtremeMarkdownOptions
     );
-    if (!jsxtremeMarkdownOptions.modules) jsxtremeMarkdownOptions.modules = [];
-    jsxtremeMarkdownOptions.modules.push(
+    if (!jsxtremeMarkdownOptions.prependJs)
+      jsxtremeMarkdownOptions.prependJs = [];
+    jsxtremeMarkdownOptions.prependJs.push(
       `import { prefixUrl, prefixUrlAbsolute } from '@mapbox/batfish/modules/prefix-url';`
     );
-    jsxtremeMarkdownOptions.modules.push(
+    jsxtremeMarkdownOptions.prependJs.push(
       `import { routeTo, routeToPrefixed } from '@mapbox/batfish/modules/route-to';`
     );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,27 @@
 {
   "name": "@mapbox/batfish",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@mapbox/babel-plugin-transform-jsxtreme-markdown": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/babel-plugin-transform-jsxtreme-markdown/-/babel-plugin-transform-jsxtreme-markdown-0.3.0.tgz",
-      "integrity": "sha512-n7/LrQAVNCcwCHUPOIXLRRqzDFZJSMjb0C8xWt4KnAZPIpapkUdfgPUDo91ATKeMlAITnlcNEMWiu2zvu1CzBw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/babel-plugin-transform-jsxtreme-markdown/-/babel-plugin-transform-jsxtreme-markdown-0.4.0.tgz",
+      "integrity": "sha512-kYG38LM0IGINg9j/fBnllqwCNOLUXHkXDnW3obxh+Dx+XG8v9LQeigaHgp19ERCu7V+LEBUGc0wHs8px+K8q+g==",
       "requires": {
-        "@mapbox/jsxtreme-markdown": "0.6.0",
+        "@mapbox/jsxtreme-markdown": "0.7.1",
         "babylon": "6.17.4"
       }
     },
     "@mapbox/jsxtreme-markdown": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/jsxtreme-markdown/-/jsxtreme-markdown-0.6.0.tgz",
-      "integrity": "sha512-xek+3lm79H3yh273/ofkB92qGhYVwjKhoZMJmnWhjYBDoFz5Luj7ZHETWQmmEXd0rvTJt8jsrWwec3xcwJl73g==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsxtreme-markdown/-/jsxtreme-markdown-0.7.1.tgz",
+      "integrity": "sha512-nj36KcliyERdV/Roydw32MZ2BogStcWEGDFibUztcMjMzkZQtM200dOQ4a6KbrupzQLL7P+oCb/yHv6VcoGtpg==",
       "requires": {
         "babel-code-frame": "6.22.0",
+        "babel-core": "6.25.0",
+        "babel-preset-es2015": "6.24.1",
+        "babel-preset-react": "6.24.1",
         "balanced-match": "1.0.0",
         "block-elements": "1.2.0",
         "front-matter": "2.1.2",
@@ -37,11 +40,11 @@
       }
     },
     "@mapbox/jsxtreme-markdown-loader": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/jsxtreme-markdown-loader/-/jsxtreme-markdown-loader-0.4.0.tgz",
-      "integrity": "sha512-oO9swfY5NGxbw8tM8r3SbcmBsWfGDeNKZIvg7fea5yx3uaWVD2U8g9MBRSXsh8GIG6YNhLowSJbfqH19VPUk3Q==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsxtreme-markdown-loader/-/jsxtreme-markdown-loader-0.5.0.tgz",
+      "integrity": "sha512-gl9rWqdkn1SBfYAX8VkjdvcZig5vfbJ6wnGD6npOOq20xO4JP1vXOd/8awC/af6YHrx7xu3e7mwiKxC78cgaYw==",
       "requires": {
-        "@mapbox/jsxtreme-markdown": "0.6.0",
+        "@mapbox/jsxtreme-markdown": "0.7.1",
         "loader-utils": "1.1.0"
       }
     },
@@ -2697,9 +2700,9 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detab": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/detab/-/detab-2.0.0.tgz",
-      "integrity": "sha1-SFvXlU0jSAkumY9/8aef2Yadm1A=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detab/-/detab-2.0.1.tgz",
+      "integrity": "sha512-/hhdqdQc5thGrqzjyO/pz76lDZ5GSuAs6goxOaKTsvPk7HNnzAyFN5lyHgqpX4/s1i66K8qMGj+VhA9504x7DQ==",
       "requires": {
         "repeat-string": "1.6.1"
       }
@@ -7619,7 +7622,7 @@
       "integrity": "sha1-8Rbovz2ncrpaOXqS2rCQ9bqRyqA=",
       "requires": {
         "collapse-white-space": "1.0.3",
-        "detab": "2.0.0",
+        "detab": "2.0.1",
         "mdast-util-definitions": "1.2.2",
         "normalize-uri": "1.1.0",
         "trim": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
     "clearMocks": true
   },
   "dependencies": {
-    "@mapbox/babel-plugin-transform-jsxtreme-markdown": "^0.3.0",
-    "@mapbox/jsxtreme-markdown-loader": "^0.4.0",
+    "@mapbox/babel-plugin-transform-jsxtreme-markdown": "^0.4.0",
+    "@mapbox/jsxtreme-markdown-loader": "^0.5.0",
     "@mapbox/link-hijacker": "^0.3.1",
     "@mapbox/link-to-location": "^0.1.0",
     "@mapbox/postcss-html-filter": "^0.2.0",


### PR DESCRIPTION
The change here is that jsxtreme-markdown's `modules` front matter option is now `prependJs`.