### PR TITLE
Smarten up about es6-promise polyfill inclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Head
+
+-   [Addition] `includePromisePolyfill` configuration option.
+-   [Fix] Batfish will inject its specified version of `es6-promise` even if something about your dependency resolution ends up putting an older version of that polyfill at `node_modules/es6-promise`.
+
 ## 0.7.0
 
 -   [Breaking change] Renamed `externalStylesheets` option to `stylesheets`.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A minimalistic static-site generator powered by React and Webpack.
 
 -   [Goals](#goals)
 -   [Usage](#usage)
+-   [Requirements](#requirements)
 -   [API](#api)
 -   [Configuration](#configuration)
     -   [CLI](#cli)
@@ -62,6 +63,13 @@ Batfish provides _the essentials_ for building excellent static websites with Re
 4.  At some point, build your static site and deploy it.
 
 Have a look at [`examples/basic/`](examples/basic) for a simple example project.
+
+## Requirements
+
+-   You'll need Node >=4.
+-   The client-side code has been tested down to IE11.
+    To support IE11, **a Promise polyfill is included by default.**
+    If you would like to provide your own Promise polyfill, set the [`includePromisePolyfill`] option to `false`.
 
 ## API
 
@@ -323,6 +331,8 @@ Additional documentation can be found in [`docs/advanced-usage.md`](docs/advance
 [`production`]: docs/configuration.md#production
 
 [`stylesheets`]: docs/configuration.md#stylesheets
+
+[`includepromisepolyfill`]: docs/configuration.md#includepromisepolyfill
 
 [`webpackloaders`]: docs/configuration.md#webpackloaders
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,7 @@ You can specify an alternate location.
     -   [postcssPlugins](#postcssplugins)
     -   [fileLoaderExtensions](#fileloaderextensions)
     -   [jsxtremeMarkdownOptions](#jsxtrememarkdownoptions)
+    -   [includePromisePolyfill](#includepromisepolyfill)
     -   [inlineJs](#inlinejs)
     -   [production](#production)
     -   [developmentDevtool](#developmentdevtool)
@@ -220,6 +221,15 @@ A transform function is probably preferable if you only need to add or remove an
 Provide any of the following [jsxtreme-markdown] options (please read about them in [jsxtreme-markdown] docs): `delimiters`, `escapeDelimiter`, `remarkPlugins`, `rehypePlugins`, `wrapper`, `modules`, `name`, `template`.
 
 **To add syntax highlighting to your Markdown pages, you'll probably want to use `remarkPlugins` or `rehypePlugins`.**
+
+### includePromisePolyfill
+
+`boolean` - Optional. Default: `true`
+
+Webpack and Batfish both rely on Promises, so if you want to support IE11 you'll need a Promise polyfill.
+
+By default, [es6-promise](https://github.com/stefanpenner/es6-promise)'s auto-polyfill is inserted at the beginning of the vendor bundle.
+**If you'd like to use your own Promise polyfill, you should set this option to `false`** (e.g. if [core-js](https://github.com/zloirock/core-js) is throwing in polyfills via some Babel tool or other).
 
 ### inlineJs
 

--- a/lib/create-webpack-config-client.js
+++ b/lib/create-webpack-config-client.js
@@ -22,8 +22,8 @@ function createWebpackConfigClient(batfishConfig, options) {
       'react',
       'react-dom',
       'react-helmet',
-      '@mapbox/scroll-restorer',
-      '@mapbox/link-hijacker'
+      require.resolve('@mapbox/scroll-restorer'),
+      require.resolve('@mapbox/link-hijacker')
     ];
     if (batfishConfig.includePromisePolyfill) {
       vendorModules.unshift(require.resolve('es6-promise/auto'));

--- a/lib/create-webpack-config-client.js
+++ b/lib/create-webpack-config-client.js
@@ -19,13 +19,15 @@ const createWebpackConfigBase = require('./create-webpack-config-base');
 function createWebpackConfigClient(batfishConfig, options) {
   return createWebpackConfigBase(batfishConfig).then(baseConfig => {
     let vendorModules = [
-      'es6-promise/auto',
       'react',
       'react-dom',
       'react-helmet',
       '@mapbox/scroll-restorer',
       '@mapbox/link-hijacker'
     ];
+    if (batfishConfig.includePromisePolyfill) {
+      vendorModules.unshift(require.resolve('es6-promise/auto'));
+    }
     if (batfishConfig.vendorModules !== undefined) {
       vendorModules = vendorModules.concat(batfishConfig.vendorModules);
     }

--- a/lib/validate-config.js
+++ b/lib/validate-config.js
@@ -29,6 +29,7 @@ const validConfigProperties = [
   'postcssPlugins',
   'fileLoaderExtensions',
   'jsxtremeMarkdownOptions',
+  'includePromisePolyfill',
   'inlineJs',
   'production',
   'developmentDevtool',
@@ -86,6 +87,7 @@ function validateConfig(config, configPath) {
       'woff2'
     ],
     jsxtremeMarkdownOptions: {},
+    includePromisePolyfill: true,
     developmentDevtool: 'source-map',
     productionDevtool: false,
     clearOutputDirectory: true

--- a/package.json
+++ b/package.json
@@ -152,5 +152,8 @@
     "remark-cli": "^4.0.0",
     "remark-validate-links": "^6.1.0"
   },
-  "optionalDependencies": {}
+  "optionalDependencies": {},
+  "engines": {
+    "node": ">=4"
+  }
 }

--- a/test/__snapshots__/validate-config.test.js.snap
+++ b/test/__snapshots__/validate-config.test.js.snap
@@ -21,6 +21,7 @@ Object {
     "woff",
     "woff2",
   ],
+  "includePromisePolyfill": true,
   "jsxtremeMarkdownOptions": Object {},
   "outputDirectory": "/my-project/_batfish_site",
   "pagesDirectory": "/my-project/src/pages",


### PR DESCRIPTION
I decided that the Promise polyfill is important enough (neither Webpack dynamic imports nor Batfish's router are designed to work without it) that we should still include it by default. I think that's also the safer bet, since *not* including a polyfill when you do need one is an easy mistake to make and to miss (you have to actually check in IE11).

- Adds an `includePromisePolyfill` option you can set to `false` if you want to use a different Promise polyfill.
- Uses `require.resolve` to add the polyfill to `vendorModules`, so it will always get Batfish's version. (Did the same thing for other default `vendorModules` that are not `peerDependencies`.)

Closes #128.