### PR TITLE
Fix CSS asset copying and referencing for static build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+-   [Fix] Fix the url-referenced assets in CSS are copied and rebased for the static build.
+
 ## 0.9.1
 
 -   [Fix] Assets referenced by `url()` in CSS you include with the `stylesheets` option are copied into the `outputDirectory`.

--- a/lib/compile-stylesheets.js
+++ b/lib/compile-stylesheets.js
@@ -15,6 +15,7 @@ const Concat = require('concat-with-sourcemaps');
 const SourceMapConsumer = require('source-map').SourceMapConsumer;
 const constants = require('./constants');
 const postcssAbsoluteUrls = require('./postcss-absolute-urls');
+const joinUrlParts = require('./join-url-parts');
 
 const urlCache = new Map();
 
@@ -73,10 +74,22 @@ function compileStylesheets(batfishConfig, cssOutputDirectory) {
   };
 
   const postcssPlugins = [
+    // Copy all url-referenced assets to the outputDirectory.
     postcssUrl({
       url: 'copy',
       assetsPath: './',
       useHash: true
+    }),
+    // Rewrite urls so they are root-relative. This way they'll work both from
+    // inlined CSS (in the static build) and the stylesheet itself.
+    postcssUrl({
+      url: asset => {
+        return joinUrlParts(
+          batfishConfig.siteBasePath,
+          constants.PUBLIC_PATH_ASSETS,
+          asset.url
+        );
+      }
     })
   ].concat(batfishConfig.postcssPlugins);
 


### PR DESCRIPTION
Turns out things need to be a little more complicated for the static build, because the CSS might reference its assets from either inlined CSS, directly in the HTML, or from the stylesheet that lazily loads. So we need the URLs to be root-relative.

Before, the static build for the initial-experiments example gave 404s for fonts. Now, both start and build should work.

@jfurrow for review.