### PR TITLE
Rename WrapperComponent to WrappedComponent in with-location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+-   [Breaking change] `with-location` now provides the original component at WrappedComponent instead of WrapperComponent.
+
 ## 0.9.4
 
 -   [Fix] Do not rebase URLs in CSS that have protocols.

--- a/src/public/with-location.js
+++ b/src/public/with-location.js
@@ -14,6 +14,6 @@ export function withLocation(Component) {
     }).isRequired
   };
 
-  WithLocation.WrapperComponent = Component;
+  WithLocation.WrappedComponent = Component;
   return WithLocation;
 }


### PR DESCRIPTION
This PR renames the key on which the original component is provided from `WrapperComponent` to `WrappedComponent`.

Closes #146 

@davidtheclark for review, please!