### PR TITLE
Watch page files for front matter changes, additions, and deletions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 -   [Add] Improve `prefixUrl` to work with already-prefixed URLs and absolute URLs.
 -   [Add] Add `unprocessedPageFiles` option.
 -   [Add] Include `babel-plugin-transform-class-properties` by default.
+-   [Add] `start` now rebuilds when you change a page's front matter, create a new page, or delete a page.
 -   [Fix] Update postcss-html-filter to fix bugs inlining CSS with certain pseudo selectors.
 
 ## 0.9.4


### PR DESCRIPTION
Closes #60.

@jfurrow for review. When you `start`, rebuilds should now happen when you change front matter, add a new page and save some content, or delete a page.