### PR TITLE
Introduce focusContentEntry module for improved screen reader experience

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -15,3 +15,4 @@ module.ignore_non_literal_requires=true
 module.name_mapper='^@mapbox/batfish/modules/route-to$' -> '<PROJECT_ROOT>/src/webpack/public/route-to.js'
 module.name_mapper='^@mapbox/batfish/modules/prefix-url$' -> '<PROJECT_ROOT>/src/webpack/public/prefix-url.js'
 module.name_mapper='^@mapbox/batfish/modules/route-change-listeners$' -> '<PROJECT_ROOT>/src/webpack/public/route-change-listeners.js'
+module.name_mapper='^@mapbox/batfish/modules/focus-content-entry$' -> '<PROJECT_ROOT>/src/webpack/public/focus-content-entry.js'

--- a/docs/batfish-modules.md
+++ b/docs/batfish-modules.md
@@ -24,6 +24,9 @@ Batfish exposes a few public modules to hook into its routing system and other i
   - [API](#api-3)
     - [withLocation](#withlocation)
   - [Example](#example)
+- [focus-content-entry](#focus-content-entry)
+  - [API](#api-4)
+    - [focusContentEntry](#focuscontententry)
 
 ## route-to
 
@@ -218,6 +221,20 @@ class MyPage extends React.Component {
 
 module.exports = withLocation(MyPage);
 ```
+
+## focus-content-entry
+
+To improve the experience of screen-reader users, this utility sets focus on your content's most meaningful entry point. It runs after each page transition and can be invoked manually as you see fit.
+
+Import from `'@mapbox/batfish/modules/focus-content-entry'`.
+
+### API
+
+The following functions are named exports of `'@mapbox/batfish/modules/focus-content-entry'`.
+
+#### focusContentEntry
+
+Sets focus on the first node matching the selector `h1, h2, h3, h4, h5, h6, main`.
 
 [`sitebasepath`]: ./configuration.md#sitebasepath
 

--- a/src/webpack/batfish-app.js
+++ b/src/webpack/batfish-app.js
@@ -4,6 +4,11 @@ import ReactDOM from 'react-dom';
 import { Router } from './router';
 import { findMatchingRoute } from './find-matching-route';
 import ApplicationWrapper from 'batfish-internal/application-wrapper';
+import {
+  addRouteChangeEndListener,
+  removeRouteChangeEndListener
+} from '@mapbox/batfish/modules/route-change-listeners';
+import { focusContentEntry } from '@mapbox/batfish/modules/focus-content-entry';
 
 // The initialization of any Batfish.
 // Get the current page and render it, wrapped in the user's ApplicationWrapper
@@ -13,6 +18,15 @@ const startingPath = window.location.pathname;
 const matchingRoute = findMatchingRoute(startingPath);
 matchingRoute.getPage().then(pageModule => {
   class App extends React.PureComponent<{}> {
+    componentDidMount() {
+      focusContentEntry();
+      addRouteChangeEndListener(focusContentEntry);
+    }
+
+    componentWillUnmount() {
+      removeRouteChangeEndListener(focusContentEntry);
+    }
+
     shouldComponentUpdate() {
       return false;
     }

--- a/src/webpack/public/focus-content-entry.js
+++ b/src/webpack/public/focus-content-entry.js
@@ -1,0 +1,12 @@
+// @flow
+
+function focusContentEntry() {
+  const contentEntry = document.querySelector('h1, h2, h3, h4, h5, h6, main');
+
+  if (contentEntry) {
+    contentEntry.setAttribute('tabindex', '-1');
+    contentEntry.focus();
+  }
+}
+
+export { focusContentEntry };

--- a/src/webpack/public/focus-content-entry.js
+++ b/src/webpack/public/focus-content-entry.js
@@ -1,12 +1,44 @@
 // @flow
 
-function focusContentEntry() {
-  const contentEntry = document.querySelector('h1, h2, h3, h4, h5, h6, main');
+const contentEntryElement = document.createElement('div');
+contentEntryElement.setAttribute(
+  'style',
+  `border: 0; clip: rect(0 0 0 0); height: 1px; margin: -1px; overflow: hidden; padding: 0; position: absolute; width: 1px; white-space: nowrap;`
+);
+contentEntryElement.setAttribute('tabindex', '-1');
 
-  if (contentEntry) {
-    contentEntry.setAttribute('tabindex', '-1');
-    contentEntry.focus();
+function prependContentEntryElement() {
+  if (!document.body.contains(contentEntryElement)) {
+    const firstBodyChild = document.body.firstChild;
+
+    if (firstBodyChild) {
+      document.body.insertBefore(contentEntryElement, firstBodyChild);
+    } else {
+      document.body.appendChild(contentEntryElement);
+    }
   }
+}
+
+function updateContentEntryElementText() {
+  const titleElement = document.querySelector('title');
+
+  if (titleElement) {
+    contentEntryElement.textContent = titleElement.textContent;
+  } else {
+    contentEntryElement.textContent = '';
+  }
+}
+
+function focusContentEntry() {
+  // We requestAnimationFrame in case the browser is busy with another task.
+  // We also use a 100ms timeout because it takes a while for React to render the component tree.
+  requestAnimationFrame(() => {
+    setTimeout(() => {
+      updateContentEntryElementText();
+      prependContentEntryElement();
+      contentEntryElement.focus();
+    }, 100);
+  });
 }
 
 export { focusContentEntry };

--- a/test/focus-content-entry.test.js
+++ b/test/focus-content-entry.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const focusContentEntry = require('../src/webpack/public/focus-content-entry')
+  .focusContentEntry;
+
+describe('focusContentEntry', () => {
+  const focusMock = jest.fn();
+  const setAttributeMock = jest.fn();
+  const querySelectorMock = jest.fn();
+
+  beforeEach(() => {
+    global.document = {
+      querySelector: querySelectorMock.mockReturnValue({
+        focus: focusMock,
+        setAttribute: setAttributeMock
+      })
+    };
+  });
+
+  afterEach(() => {
+    delete global.document;
+  });
+
+  test('focuses on the returned element', () => {
+    focusContentEntry();
+    expect(querySelectorMock).toHaveBeenCalledTimes(1);
+    expect(focusMock).toHaveBeenCalledTimes(1);
+    expect(setAttributeMock).toHaveBeenCalledWith('tabindex', '-1');
+  });
+
+  test('does not focus when no elements match selector', () => {
+    querySelectorMock.mockReturnValue(null);
+    focusContentEntry();
+    expect(querySelectorMock).toHaveBeenCalledTimes(1);
+    expect(focusMock).not.toHaveBeenCalled();
+    expect(setAttributeMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Originally introduced at https://github.com/mapbox/www.mapbox.com/pull/2257

This PR introduces a utility called `focusContentEntry` which gets invoked on each page transition. It will give screen readers a better experience by shifting the focus to the first important bit of text.

Ideally this is an `h1`, but that's not always the case, so the utility will search for all heading levels and default to the `main` element.

You can test this with VoiceOver in MacOS (enable by pushing `command` + `f5`, or go to System Preferences > Accessibility > VoiceOver).

If a user doesn't specifically styling the `:focus` state of these elements, this module will result in things like this:
![screen shot 2017-09-01 at 2 36 37 pm](https://user-images.githubusercontent.com/1134755/29989262-b8a9dee8-8f26-11e7-83c2-09236b0dc1a3.png)

**Questions**

Do you think we should be concerned about the focus state styling? I don't, personally.

How much configuration do you think we should provide with this? Some ideas would be specifying custom content-entry selectors or disabling it entirely.

**Reviewers**

@davidtheclark 