### PR TITLE
Fix double compile

### DIFF
--- a/src/node/start.js
+++ b/src/node/start.js
@@ -180,7 +180,11 @@ function start(rawConfig?: Object, projectDirectory?: string): EventEmitter {
 
     compiler.watch(
       {
-        ignored: [/node_modules/, pageGlob]
+        ignored: [
+          /node_modules/,
+          pageGlob,
+          path.join(batfishConfig.temporaryDirectory, './**/*')
+        ]
       },
       onCompilation
     );


### PR DESCRIPTION
This PR fixes a bug that @lshig and I noticed on the mapbox.com repository today. Every file change triggered two compilations, resulting in a chunk's request failure, which totally breaks the UI.

I tested this in the mapbox.com repo locally and it worked as intended. I was _not_ able to reproduce this in the Batfish examples, which is a little concerning.