### PR TITLE
Improve filename hashing for long-term caching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/batfish",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/node/create-webpack-config-client.js
+++ b/src/node/create-webpack-config-client.js
@@ -65,7 +65,8 @@ function createWebpackConfigClient(
       }),
       // Extract universal vendor files (defined above) from everything else.
       new webpack.optimize.CommonsChunkPlugin({
-        name: 'vendor'
+        name: 'vendor',
+        minChunks: Infinity
       }),
       // Bundle together any other modules from anywhere imported more than 3 times.
       new webpack.optimize.CommonsChunkPlugin({
@@ -74,8 +75,16 @@ function createWebpackConfigClient(
         minChunks: 4
       }),
       // Trying to follow advice for long-term caching described here:
+      // https://webpack.js.org/guides/caching/#extracting-boilerplate and
       // https://jeremygayed.com/dynamic-vendor-bundling-in-webpack-528993e48aab#.hjgai17ap
+      // Because 'manifest' does not correspond to an entry name, this chunk
+      // will include Webpack's runtime boilerplate and manifest, which can
+      // change with each build. During the static build we inject it directly
+      // into the HTML, so those variations do not ruin caching on large chunks.
       new webpack.optimize.CommonsChunkPlugin('manifest'),
+      // Recommended at https://webpack.js.org/guides/caching/#module-identifiers
+      // as a way to make module IDs more deterministic.
+      new webpack.HashedModuleIdsPlugin(),
       // Define an environment variable for special cases
       new webpack.DefinePlugin({
         'process.env.DEV_SERVER': (options && options.devServer) || false

--- a/test/__snapshots__/create-webpack-config-client.test.js.snap
+++ b/test/__snapshots__/create-webpack-config-client.test.js.snap
@@ -41,7 +41,7 @@ Object {
       ],
       "filenameTemplate": undefined,
       "ident": "<PROJECT_ROOT>/node_modules/webpack/lib/optimize/CommonsChunkPlugin.js3",
-      "minChunks": undefined,
+      "minChunks": Infinity,
       "minSize": undefined,
       "selectedChunks": undefined,
     },
@@ -68,6 +68,13 @@ Object {
       "minChunks": undefined,
       "minSize": undefined,
       "selectedChunks": undefined,
+    },
+    HashedModuleIdsPlugin {
+      "options": Object {
+        "hashDigest": "base64",
+        "hashDigestLength": 4,
+        "hashFunction": "md5",
+      },
     },
     DefinePlugin {
       "definitions": Object {
@@ -127,7 +134,7 @@ Object {
       ],
       "filenameTemplate": undefined,
       "ident": "<PROJECT_ROOT>/node_modules/webpack/lib/optimize/CommonsChunkPlugin.js6",
-      "minChunks": undefined,
+      "minChunks": Infinity,
       "minSize": undefined,
       "selectedChunks": undefined,
     },
@@ -154,6 +161,13 @@ Object {
       "minChunks": undefined,
       "minSize": undefined,
       "selectedChunks": undefined,
+    },
+    HashedModuleIdsPlugin {
+      "options": Object {
+        "hashDigest": "base64",
+        "hashDigestLength": 4,
+        "hashFunction": "md5",
+      },
     },
     DefinePlugin {
       "definitions": Object {
@@ -222,7 +236,7 @@ Object {
       ],
       "filenameTemplate": undefined,
       "ident": "<PROJECT_ROOT>/node_modules/webpack/lib/optimize/CommonsChunkPlugin.js9",
-      "minChunks": undefined,
+      "minChunks": Infinity,
       "minSize": undefined,
       "selectedChunks": undefined,
     },
@@ -249,6 +263,13 @@ Object {
       "minChunks": undefined,
       "minSize": undefined,
       "selectedChunks": undefined,
+    },
+    HashedModuleIdsPlugin {
+      "options": Object {
+        "hashDigest": "base64",
+        "hashDigestLength": 4,
+        "hashFunction": "md5",
+      },
     },
     DefinePlugin {
       "definitions": Object {

--- a/test/__snapshots__/write-context-module.test.js.snap
+++ b/test/__snapshots__/write-context-module.test.js.snap
@@ -9,6 +9,14 @@ exports[`writeContextModule with 404 and some config variation 1`] = `
   },
   routes: [
     {
+      path: \\"/404/\\",
+      getPage: () =>
+        import(/* webpackChunkName: \\"not-found\\" */
+        \\"module/file/path/forfake/pages/directory/404.js\\"),
+
+      is404: true
+    },
+    {
       path: \\"/one/\\",
       getPage: () =>
         import(/* webpackChunkName: \\"one\\" */
@@ -19,14 +27,6 @@ exports[`writeContextModule with 404 and some config variation 1`] = `
       getPage: () =>
         import(/* webpackChunkName: \\"three-four\\" */
         \\"module/file/path/forfake/pages/directory/three/four/index.js\\")
-    },
-    {
-      path: \\"/404/\\",
-      getPage: () =>
-        import(/* webpackChunkName: \\"not-found\\" */
-        \\"module/file/path/forfake/pages/directory/404.js\\"),
-
-      is404: true
     }
   ],
   notFoundRoute: {
@@ -56,16 +56,16 @@ exports[`writeContextModule without 404 1`] = `
         \\"module/file/path/forfake/pages/directory/one.js\\")
     },
     {
-      path: \\"/two/\\",
-      getPage: () =>
-        import(/* webpackChunkName: \\"two\\" */
-        \\"module/file/path/forfake/pages/directory/two/index.md\\")
-    },
-    {
       path: \\"/three/four/\\",
       getPage: () =>
         import(/* webpackChunkName: \\"three-four\\" */
         \\"module/file/path/forfake/pages/directory/three/four/index.js\\")
+    },
+    {
+      path: \\"/two/\\",
+      getPage: () =>
+        import(/* webpackChunkName: \\"two\\" */
+        \\"module/file/path/forfake/pages/directory/two/index.md\\")
     }
   ],
   notFoundRoute: {


### PR DESCRIPTION
Closes #184.

Introduces HashedModuleIdsPlugin and sorts routes in the context module.

I experimented in the examples with this and the results are looking good. When I modify a single page, only that's page bundle's hash changes. When I modify a component shared by 4 pages, only the app bundle's hash changes. And so on. Seems to be working exactly as we'd hope.