### PR TITLE
Prevent hashes for NamedChunksPlugin that are too long for filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- Fix bug that could cause builds with unnamed dynamic imports to fail with a cryptic error about a hash-based filename that is too long.
+
 ## 1.0.4
 
 - Fix bug causing build to fail if you used `npm link` (or `yarn link`), with a message about failing to find Babel plugins.
@@ -106,10 +110,10 @@
 - **[Breaking change]** `with-location` now provides the original component at WrappedComponent instead of WrapperComponent.
 - **[Breaking change]** change `data-no-hijack` attribute name to `data-batfish-no-hijack`.
   Also, this attribute now blocks link hijacking on the element itself *and all its children*.
-- **[Breaking change]** (maybe, maybe not) Links with fragment URLs (e.g. `href="#foo"`) are not hijacked, just left to their default behavior.  
-- [Add] Much improved logging!  
-- [Add] Much improved configuration validation!  
-- [Add] Much improved error handling!  
+- **[Breaking change]** (maybe, maybe not) Links with fragment URLs (e.g. `href="#foo"`) are not hijacked, just left to their default behavior.
+- [Add] Much improved logging!
+- [Add] Much improved configuration validation!
+- [Add] Much improved error handling!
 - [Add] `hijackLinks` configuration option, defaulting to `true`.
 - [Add] Improve `prefixUrl` to work with already-prefixed URLs and absolute URLs.
 - [Add] Add `unprocessedPageFiles` option.

--- a/src/node/create-webpack-config-client.js
+++ b/src/node/create-webpack-config-client.js
@@ -87,21 +87,19 @@ function createWebpackConfigClient(
       new webpack.HashedModuleIdsPlugin(),
       new webpack.NamedChunksPlugin(chunk => {
         if (chunk.name) return chunk.name;
-        return chunk.modules
-          .map(module => {
-            const hashSeed = path.relative(
-              batfishConfig.pagesDirectory,
-              module.resource
-            );
-            const requestHash = crypto
-              .createHash('md5')
-              .update(hashSeed)
-              .digest('hex');
-            return requestHash;
+        const hashSeed = chunk.modules
+          .map(m => m.resource || '')
+          .sort()
+          .map(resource => {
+            return path.relative(batfishConfig.pagesDirectory, resource);
           })
           .join('_');
-      }),
-      // Define an environment variable for special cases
+        const chunkHash = crypto
+          .createHash('md5')
+          .update(hashSeed)
+          .digest('hex');
+        return chunkHash;
+      }), // Define an environment variable for special cases
       new webpack.DefinePlugin({
         'process.env.DEV_SERVER': (options && options.devServer) || false
       })


### PR DESCRIPTION
I ran into this bug when I dynamically `import()`ed something huge, without providing a name for the Webpack async chunk.