### PR TITLE
Remove json-loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Head
 
+- Remove json-loader, which Webpack no longer needs to import JSON.
 - Fix bug that could cause builds with unnamed dynamic imports to fail with a cryptic error about a hash-based filename that is too long.
 
 ## 1.0.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/batfish",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "ignore-loader": "^0.1.2",
     "indefinite": "^2.1.1",
     "is-glob": "^4.0.0",
-    "json-loader": "^0.5.7",
     "loader-utils": "^1.1.0",
     "lodash": "^4.17.5",
     "meow": "^4.0.0",

--- a/src/node/create-webpack-config-base.js
+++ b/src/node/create-webpack-config-base.js
@@ -132,11 +132,6 @@ function createWebpackConfigBase(
             ? '[name]-[hash].[ext]'
             : '[name].[ext]'
         }
-      },
-      // JSON!
-      {
-        test: /\.json$/,
-        use: 'json-loader'
       }
     ];
     if (batfishConfig.pageSpecificCss) {

--- a/test/__snapshots__/create-webpack-config-base.test.js.snap
+++ b/test/__snapshots__/create-webpack-config-base.test.js.snap
@@ -95,10 +95,6 @@ Object {
         "test": /\\\\\\.\\(jpeg\\|jpg\\|png\\|gif\\|webp\\|mp4\\|webm\\|woff\\|woff2\\)\\$/,
       },
       Object {
-        "test": /\\\\\\.json\\$/,
-        "use": "json-loader",
-      },
-      Object {
         "test": /<PROJECT_ROOT>\\\\/test\\\\/fixtures\\\\/get-pages-data\\.\\*\\\\\\.css\\$/,
         "use": Array [
           Object {
@@ -275,10 +271,6 @@ Object {
           "name": "[name]-[hash].[ext]",
         },
         "test": /\\\\\\.\\(jpeg\\|jpg\\|png\\|gif\\|webp\\|mp4\\|webm\\|woff\\|woff2\\)\\$/,
-      },
-      Object {
-        "test": /\\\\\\.json\\$/,
-        "use": "json-loader",
       },
       Object {
         "test": /<PROJECT_ROOT>\\\\/test\\\\/fixtures\\\\/get-pages-data\\.\\*\\\\\\.css\\$/,
@@ -479,10 +471,6 @@ Object {
           "name": "[name].[ext]",
         },
         "test": /\\\\\\.\\(txt\\|config\\)\\$/,
-      },
-      Object {
-        "test": /\\\\\\.json\\$/,
-        "use": "json-loader",
       },
       Object {
         "test": /<PROJECT_ROOT>\\\\/test\\\\/fixtures\\\\/get-pages-data\\.\\*\\\\\\.css\\$/,


### PR DESCRIPTION
Webpack no longer needs this to import JSON.

Closes #202.

Verified that this works by tinkering with some JSON in the demos.