### PR TITLE
babelInclude option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - **Add:** `batfish write-bablerc` command (`batfish.writeBabelrc` in Node API), which writes a `.babelrc` file that you can use to tell other process, like a test runner, how to interpret your source files.
 - **Chore:** Remove json-loader, which Webpack no longer needs to import JSON.
 - **Fix:** Fix bug that could cause builds with unnamed dynamic imports to fail with a cryptic error about a hash-based filename that is too long.
+- **Chore:** Remove json-loader, which Webpack no longer needs to import JSON.
+- **Chore:** Allow babel-loader to use its default cache location (`node_modules/.cache/babel-loader`).
 
 ## 1.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - **Add:** `batfish write-bablerc` command (`batfish.writeBabelrc` in Node API), which writes a `.babelrc` file that you can use to tell other process, like a test runner, how to interpret your source files.
 - **Chore:** Remove json-loader, which Webpack no longer needs to import JSON.
+- **Add:** Add `babelInclude` option.
+- **Fix:** Tweak default `babelExclude` value to ensure it excludes nested `node_modules` directories.
 - **Fix:** Fix bug that could cause builds with unnamed dynamic imports to fail with a cryptic error about a hash-based filename that is too long.
 - **Chore:** Remove json-loader, which Webpack no longer needs to import JSON.
 - **Chore:** Allow babel-loader to use its default cache location (`node_modules/.cache/babel-loader`).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,6 +41,7 @@ You can specify an alternate location.
   - [babelPresets](#babelpresets)
   - [babelPresetEnvOptions](#babelpresetenvoptions)
   - [babelExclude](#babelexclude)
+  - [babelInclude](#babelinclude)
   - [postcssPlugins](#postcssplugins)
   - [fileLoaderExtensions](#fileloaderextensions)
   - [jsxtremeMarkdownOptions](#jsxtrememarkdownoptions)
@@ -266,11 +267,55 @@ Use this option to further customize your build by passing any of the other many
 ### babelExclude
 
 Type: [Webpack `Condition`].
-Default: `/node_modules\/!(@mapbox\/batfish\/)/`.
+Default: `/[/\\\\]node_modules[/\\\\]/`. (A nasty regular expression that excludes all nested `node_modules`.)
 
-Any valid [Webpack `Condition`] will work here.
+By default, all packages installed by npm are excluded from Babel compilation (see [`babelExclude`]).
+If you'd like to change that (e.g. to exclude more files), provide a valid [Webpack `Condition`].
 
-You'll need to use this if, for example, you use a library that includes ES2015 but is not compiled for publication (e.g. any of the [promise-fun](https://github.com/sindresorhus/promise-fun) modules).
+Make sure your condition somehow excludes the majority of `node_modules` from compilation, or your builds could slow down dramatically.
+
+### babelInclude
+
+Type: `Array<string | Condition>`.
+Default: `[]`.
+
+By default, all packages installed by npm are excluded from Babel compilation (see [`babelExclude`]).
+If, however, you use a library that includes ES2015+ but does not get compiled for publication (e.g. any of the [promise-fun](https://github.com/sindresorhus/promise-fun) modules), then you'll need to pass that module through Babel.
+That's what this option is for.
+
+The easiest way to include an npm package in your compilation is to pass its name as a string.
+
+But if you have more complex needs, any valid [Webpack `Condition`] will work here.
+All conditions will be combined with `test: /\.jsx$/` so only `.js` or `.jsx` files are compiled.
+
+Some examples:
+
+To compile `p-queue`:
+
+```js
+[`p-queue`]
+```
+
+To compile both `p-queue` and `@mapbox/mapbox-gl-style-spec` *except for* its `dist/` directory and any nested `node_modules`:
+
+```js
+[
+  'p-queue',
+  {
+    include: path.resolve(__dirname, 'node_modules/@mapbox/mapbox-gl-style-spec'),
+    exclude: [
+      path.resolve(
+        __dirname,
+        'node_modules/@mapbox/mapbox-gl-style-spec/dist'
+      ),
+      path.resolve(
+        __dirname,
+        'node_modules/@mapbox/mapbox-gl-style-spec/node_modules'
+      )
+    ]
+  }
+]
+```
 
 ### postcssPlugins
 
@@ -430,6 +475,8 @@ If `true`, more information will be logged to the console.
 [`pagesdirectory`]: #pagesdirectory
 
 [`stylesheets`]: #stylesheets
+
+[`babelexclude`]: #babelexclude
 
 [`jsxtrememarkdownoptions`]: #jsxtrememarkdownoptions
 

--- a/flow-typed/defs.js
+++ b/flow-typed/defs.js
@@ -29,6 +29,7 @@ declare type BatfishConfiguration = {
   babelPresets: Array<string>,
   babelPresetEnvOptions?: Object,
   babelExclude: webpack$Condition,
+  babelInclude: Array<string | webpack$Condition>,
   postcssPlugins?: Array<Function>,
   fileLoaderExtensions: Array<string>,
   jsxtremeMarkdownOptions: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1399,13 +1399,13 @@
       }
     },
     "babel-jest": {
-      "version": "22.4.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.0.tgz",
-      "integrity": "sha512-A/safCd5jSf1D98XoHCN3YYuGurtUPntuPh8b7UxsLNfEp/QC8UwdL+VEGSLN5Fk3+tS/Jdbf5NK/T2it8RGYw==",
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.1.tgz",
+      "integrity": "sha512-rEdN/jevSuX0IQKcUqwqOGa0gDNis4jGY52Rq53aizfDGPwQYNJq+f9NCMT1HUhtUZhYSjvfGUfHQWBRT1/icA==",
       "dev": true,
       "requires": {
         "babel-plugin-istanbul": "4.1.5",
-        "babel-preset-jest": "22.2.0"
+        "babel-preset-jest": "22.4.1"
       }
     },
     "babel-loader": {
@@ -1457,9 +1457,9 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.2.0.tgz",
-      "integrity": "sha512-NwicD5n1YQaj6sM3PVULdPBDk1XdlWvh8xBeUJg3nqZwp79Vofb8Q7GOVeWoZZ/RMlMuJMMrEAgSQl/p392nLA==",
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.1.tgz",
+      "integrity": "sha512-gmj5FvFflXSnRapWmF/jDjx5Lof1kX0OwXibCxMOx38V3CFMOnTxLTUrAFfLkhCey3FJvv0ACvv/+h4nzFRxhg==",
       "dev": true
     },
     "babel-plugin-syntax-async-functions": {
@@ -1969,12 +1969,12 @@
       }
     },
     "babel-preset-jest": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.2.0.tgz",
-      "integrity": "sha512-p61cPMGYlSgfNScn1yQuVnLguWE4bjhB/br4KQDMbYZG+v6ryE5Ch7TKukjA6mRuIQj1zhyou7Sbpqrh4/N6Pg==",
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.1.tgz",
+      "integrity": "sha512-gW3+spyB8fkSAI9fX+41BQMwar5LjR+nyKa2QRvK22snxnI29+jJVAMfId+osucFJzJJvhlvzKWnfwX8Omodvg==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "22.2.0",
+        "babel-plugin-jest-hoist": "22.4.1",
         "babel-plugin-syntax-object-rest-spread": "6.13.0"
       }
     },
@@ -5148,7 +5148,7 @@
       "integrity": "sha512-Fiy862jT3qc70hwIHwwCBNISmaqBrfWKKrtqyMJ6iwZr+6KXtcnHojZFtd63TPRvRl8EQTJ+YXYy2lK6/6u+Hw==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.0",
+        "ansi-styles": "3.2.1",
         "jest-diff": "22.4.0",
         "jest-get-type": "22.1.0",
         "jest-matcher-utils": "22.4.0",
@@ -5157,9 +5157,9 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -8718,13 +8718,13 @@
       }
     },
     "jest": {
-      "version": "22.4.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-22.4.0.tgz",
-      "integrity": "sha512-eze1JLbBDkrbZMnE6xIlBxHkqPAmuHbz4GQbED8qRVtnpea3o6Tt/Dc3SBs3qnlTo7svema8Ho5bqLfdHyabyQ==",
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-22.4.2.tgz",
+      "integrity": "sha512-wD7dXWtfaQAgbNVsjFqzmuhg6nzwGsTRVea3FpSJ7GURhG+J536fw4mdoLB01DgiEozDDeF1ZMR/UlUszTsCrg==",
       "dev": true,
       "requires": {
         "import-local": "1.0.0",
-        "jest-cli": "22.4.0"
+        "jest-cli": "22.4.2"
       },
       "dependencies": {
         "camelcase": {
@@ -8774,9 +8774,9 @@
           "dev": true
         },
         "jest-cli": {
-          "version": "22.4.0",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.0.tgz",
-          "integrity": "sha512-0JlBb/PvHGQZR2I9GZwsycHgWHhriBmvBWPaaPYUT186oiIIDY4ezDxFOFt2Ts0yNTRg3iY9mTyHsfWbT5VRWA==",
+          "version": "22.4.2",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.2.tgz",
+          "integrity": "sha512-ebo6ZWK2xDSs7LGnLvM16SZOIJ2dj0B6/oERmGcal32NHkks450nNfGrGTyOSPgJDgH8DFhVdBXgSamN7mtZ0Q==",
           "dev": true,
           "requires": {
             "ansi-escapes": "3.0.0",
@@ -8791,18 +8791,18 @@
             "istanbul-lib-instrument": "1.9.2",
             "istanbul-lib-source-maps": "1.2.3",
             "jest-changed-files": "22.2.0",
-            "jest-config": "22.4.0",
-            "jest-environment-jsdom": "22.4.0",
+            "jest-config": "22.4.2",
+            "jest-environment-jsdom": "22.4.1",
             "jest-get-type": "22.1.0",
-            "jest-haste-map": "22.4.0",
+            "jest-haste-map": "22.4.2",
             "jest-message-util": "22.4.0",
             "jest-regex-util": "22.1.0",
             "jest-resolve-dependencies": "22.1.0",
-            "jest-runner": "22.4.0",
-            "jest-runtime": "22.4.0",
+            "jest-runner": "22.4.2",
+            "jest-runtime": "22.4.2",
             "jest-snapshot": "22.4.0",
-            "jest-util": "22.4.0",
-            "jest-validate": "22.4.0",
+            "jest-util": "22.4.1",
+            "jest-validate": "22.4.2",
             "jest-worker": "22.2.2",
             "micromatch": "2.3.11",
             "node-notifier": "5.2.1",
@@ -8813,6 +8813,19 @@
             "strip-ansi": "4.0.0",
             "which": "1.2.14",
             "yargs": "10.1.2"
+          }
+        },
+        "jest-validate": {
+          "version": "22.4.2",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.2.tgz",
+          "integrity": "sha512-TLOgc/EULFBjMCAqZp5OdVvjxV16DZpfthd/UyPzM6lRmgWluohNVemAdnL3JvugU1s2Q2npcIqtbOtiPjaZ0A==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.1",
+            "jest-config": "22.4.2",
+            "jest-get-type": "22.1.0",
+            "leven": "2.1.0",
+            "pretty-format": "22.4.0"
           }
         },
         "os-locale": {
@@ -8883,21 +8896,21 @@
       }
     },
     "jest-config": {
-      "version": "22.4.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.0.tgz",
-      "integrity": "sha512-hZs8qHjCybOpqni0Kwt40eAavYN/3KnJJwYxSJsBRedJ98IgGSiI18SjybCSccKayA7eHgw1A+dLkHcfI4LItQ==",
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.2.tgz",
+      "integrity": "sha512-oG31qYO73/3vj/Q8aM2RgzmHndTkz9nRk8ISybfuJqqbf0RW7OUjHVOZPLOUiwLWtz52Yq2HkjIblsyhbA7vrg==",
       "dev": true,
       "requires": {
         "chalk": "2.3.1",
         "glob": "7.1.2",
-        "jest-environment-jsdom": "22.4.0",
-        "jest-environment-node": "22.4.0",
+        "jest-environment-jsdom": "22.4.1",
+        "jest-environment-node": "22.4.1",
         "jest-get-type": "22.1.0",
-        "jest-jasmine2": "22.4.0",
+        "jest-jasmine2": "22.4.2",
         "jest-regex-util": "22.1.0",
-        "jest-resolve": "22.4.0",
-        "jest-util": "22.4.0",
-        "jest-validate": "22.4.0",
+        "jest-resolve": "22.4.2",
+        "jest-util": "22.4.1",
+        "jest-validate": "22.4.2",
         "pretty-format": "22.4.0"
       },
       "dependencies": {
@@ -8913,6 +8926,19 @@
             "minimatch": "3.0.4",
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
+          }
+        },
+        "jest-validate": {
+          "version": "22.4.2",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.2.tgz",
+          "integrity": "sha512-TLOgc/EULFBjMCAqZp5OdVvjxV16DZpfthd/UyPzM6lRmgWluohNVemAdnL3JvugU1s2Q2npcIqtbOtiPjaZ0A==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.1",
+            "jest-config": "22.4.2",
+            "jest-get-type": "22.1.0",
+            "leven": "2.1.0",
+            "pretty-format": "22.4.0"
           }
         }
       }
@@ -8939,24 +8965,24 @@
       }
     },
     "jest-environment-jsdom": {
-      "version": "22.4.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.0.tgz",
-      "integrity": "sha512-SAUCte4KFLaD2YhYwHFVEI2GkR4BHqHJsnbFgmQMGgHnZ2CfjSZE8Bnb+jlarbxIG4GXl31+2e9rjBpzbY9gKQ==",
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.1.tgz",
+      "integrity": "sha512-x/JzAoH+dWPBnIMv5OQKiIR0TYf6UvbRjsIuDZ11yDFXkHKGJZg6jNnLAsokAm3cq9kUa2hH5BPUC9XU4n1ELQ==",
       "dev": true,
       "requires": {
         "jest-mock": "22.2.0",
-        "jest-util": "22.4.0",
+        "jest-util": "22.4.1",
         "jsdom": "11.6.2"
       }
     },
     "jest-environment-node": {
-      "version": "22.4.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.0.tgz",
-      "integrity": "sha512-ihSKa2MU5jkAhmRJ17FU4nisbbfW6spvl6Jtwmm5W9kmTVa2sa9UoHWbOWAb7HXuLi3PGGjzTfEt5o3uIzisnQ==",
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.1.tgz",
+      "integrity": "sha512-wj9+zzfRgnUbm5VwFOCGgG1QmbucUyrjPKBKUJdLW8K5Ss5zrNc1k+v6feZhFg6sS3ZGnjgtIyklaxEARxu+LQ==",
       "dev": true,
       "requires": {
         "jest-mock": "22.2.0",
-        "jest-util": "22.4.0"
+        "jest-util": "22.4.1"
       }
     },
     "jest-get-type": {
@@ -8966,9 +8992,9 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "22.4.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.0.tgz",
-      "integrity": "sha512-znYomZ+GaRcuFLQz7hmwQOfLkHY2Y2Aoyd29ZcXLrwBEWts5U/c7lFsqo54XUJUlMhrM5M2IOaAUWjZ1CRqAOQ==",
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.2.tgz",
+      "integrity": "sha512-EdQADHGXRqHJYAr7q9B9YYHZnrlcMwhx1+DnIgc9uN05nCW3RvGCxJ91MqWXcC1AzatLoSv7SNd0qXMp2jKBDA==",
       "dev": true,
       "requires": {
         "fb-watchman": "2.0.0",
@@ -8981,12 +9007,11 @@
       }
     },
     "jest-jasmine2": {
-      "version": "22.4.0",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.0.tgz",
-      "integrity": "sha512-oL7bNLfEL9jPVjmiwqQuwrAJ/5ddmKHSpns0kCpAmv1uQ47Q5aC9zBTXZbDWP5GVbVHj2hbYtNbkwTiXJr0e8w==",
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.2.tgz",
+      "integrity": "sha512-KZaIHpXQ0AIlvQJFCU0uoXxtz5GG47X14r9upMe7VXE55UazoMZBFnQb9TX2HoYX2/AxJYnjHuvwKVCFqOrEtw==",
       "dev": true,
       "requires": {
-        "callsites": "2.0.0",
         "chalk": "2.3.1",
         "co": "4.6.0",
         "expect": "22.4.0",
@@ -8996,15 +9021,8 @@
         "jest-matcher-utils": "22.4.0",
         "jest-message-util": "22.4.0",
         "jest-snapshot": "22.4.0",
+        "jest-util": "22.4.1",
         "source-map-support": "0.5.3"
-      },
-      "dependencies": {
-        "callsites": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-          "dev": true
-        }
       }
     },
     "jest-leak-detector": {
@@ -9053,9 +9071,9 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "22.4.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.0.tgz",
-      "integrity": "sha512-Vs/5VeJEHLpB0ubpYuU9QpBjcCUZRHoHnoV58ZC+N3EXyMJr/MgoqUNpo4OHGQERWlUpvl4YLAAO5uxSMF2VIg==",
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.2.tgz",
+      "integrity": "sha512-P1hSfcc2HJYT5t+WPu/11OfFMa7m8pBb2Gf2vm6W9OVs7YTXQ5RCC3nDqaYZQaTqxEM1ZZaTcQGcE6U2xMOsqQ==",
       "dev": true,
       "requires": {
         "browser-resolve": "1.11.2",
@@ -9072,43 +9090,43 @@
       }
     },
     "jest-runner": {
-      "version": "22.4.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.0.tgz",
-      "integrity": "sha512-x5QJQrSQs/oaZq2UxtKJxCjGq3fNF7guKRLxAIS39QIaRSAynS4agniMyvHMnLaYsBh6yzUea2SDeNHayQh+TQ==",
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.2.tgz",
+      "integrity": "sha512-W4vwgiVQS0NyXt8hgpw7i0YUtsfoChiQcoHWBJeq2ocV4VF2osEZx8HYgpH5HfNe1Cb5LZeZWxX8Dr3hesbGFg==",
       "dev": true,
       "requires": {
         "exit": "0.1.2",
-        "jest-config": "22.4.0",
+        "jest-config": "22.4.2",
         "jest-docblock": "22.4.0",
-        "jest-haste-map": "22.4.0",
-        "jest-jasmine2": "22.4.0",
+        "jest-haste-map": "22.4.2",
+        "jest-jasmine2": "22.4.2",
         "jest-leak-detector": "22.4.0",
         "jest-message-util": "22.4.0",
-        "jest-runtime": "22.4.0",
-        "jest-util": "22.4.0",
+        "jest-runtime": "22.4.2",
+        "jest-util": "22.4.1",
         "jest-worker": "22.2.2",
         "throat": "4.1.0"
       }
     },
     "jest-runtime": {
-      "version": "22.4.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.0.tgz",
-      "integrity": "sha512-aixL2DIXoFQ2ubnurzK4kbNXLl3+m0m7wIBb5VWaJdl1/3nV1UCSjZ9/dJZzpWGGfXsoGw2RZd8sS0nS5s+tdw==",
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.2.tgz",
+      "integrity": "sha512-9/Fxbj99cqxI7o2nTNzevnI38eDBstkwve8ZeaAD/Kz0fbU3i3eRv2QPEmzbmyCyBvUWxCT7BzNLTzTqH1+pyA==",
       "dev": true,
       "requires": {
         "babel-core": "6.25.0",
-        "babel-jest": "22.4.0",
+        "babel-jest": "22.4.1",
         "babel-plugin-istanbul": "4.1.5",
         "chalk": "2.3.1",
         "convert-source-map": "1.5.0",
         "exit": "0.1.2",
         "graceful-fs": "4.1.11",
-        "jest-config": "22.4.0",
-        "jest-haste-map": "22.4.0",
+        "jest-config": "22.4.2",
+        "jest-haste-map": "22.4.2",
         "jest-regex-util": "22.1.0",
-        "jest-resolve": "22.4.0",
-        "jest-util": "22.4.0",
-        "jest-validate": "22.4.0",
+        "jest-resolve": "22.4.2",
+        "jest-util": "22.4.1",
+        "jest-validate": "22.4.2",
         "json-stable-stringify": "1.0.1",
         "micromatch": "2.3.11",
         "realpath-native": "1.0.0",
@@ -9149,6 +9167,19 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
+        },
+        "jest-validate": {
+          "version": "22.4.2",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.2.tgz",
+          "integrity": "sha512-TLOgc/EULFBjMCAqZp5OdVvjxV16DZpfthd/UyPzM6lRmgWluohNVemAdnL3JvugU1s2Q2npcIqtbOtiPjaZ0A==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.1",
+            "jest-config": "22.4.2",
+            "jest-get-type": "22.1.0",
+            "leven": "2.1.0",
+            "pretty-format": "22.4.0"
+          }
         },
         "os-locale": {
           "version": "2.1.0",
@@ -9235,9 +9266,9 @@
       }
     },
     "jest-util": {
-      "version": "22.4.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.0.tgz",
-      "integrity": "sha512-652EArz3XScAGAUMhbny7FrFGlmJkp+56CO+9RTrKPtGfbtVDF2WB2D8G+6D6zorDmDW5hNtKNIGNdGfG2kj1g==",
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.1.tgz",
+      "integrity": "sha512-9ySBdJY2qVWpg0OvZbGcFXE2NgwccpZVj384E9bx7brKFc7l5anpqah15mseWcz7FLDk7/N+LyYgqFme7Rez2Q==",
       "dev": true,
       "requires": {
         "callsites": "2.0.0",
@@ -9245,13 +9276,20 @@
         "graceful-fs": "4.1.11",
         "is-ci": "1.0.10",
         "jest-message-util": "22.4.0",
-        "mkdirp": "0.5.1"
+        "mkdirp": "0.5.1",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "callsites": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "flow-coverage-report": "^0.4.1",
     "flow-remove-types": "^1.2.3",
     "husky": "^0.14.3",
-    "jest": "^22.4.0",
+    "jest": "^22.4.2",
     "lint-staged": "^7.0.0",
     "npm-run-all": "^4.1.2",
     "path-type": "^3.0.0",

--- a/src/node/create-webpack-config-base.js
+++ b/src/node/create-webpack-config-base.js
@@ -48,9 +48,7 @@ function createWebpackConfigBase(
     const babelLoaderConfig = {
       loader: 'babel-loader',
       options: {
-        cacheDirectory: !batfishConfig.production
-          ? path.join(__dirname, '../../babel-cache')
-          : false,
+        cacheDirectory: !batfishConfig.production,
         presets: babelConfig.presets,
         plugins: babelConfig.plugins,
         babelrc: false,

--- a/src/node/validate-config.js
+++ b/src/node/validate-config.js
@@ -97,6 +97,9 @@ const configSchema = {
   babelExclude: {
     validator: () => true
   },
+  babelInclude: {
+    validator: _.isArray
+  },
   postcssPlugins: {
     validator: x => _.isFunction(x) || isArrayOf(_.isFunction)(x),
     description: 'function or array of functions'
@@ -203,7 +206,9 @@ function validateConfig(
     babelPlugins: [],
     babelPresets: [],
     hijackLinks: true,
-    babelExclude: /node_modules\/!(@mapbox\/batfish\/)/,
+    // cf. https://github.com/facebook/create-react-app/pull/3741/files#r162787793
+    babelExclude: /[/\\\\]node_modules[/\\\\]/,
+    babelInclude: [],
     siteBasePath: '',
     browserslist: ['> 5%', 'last 2 versions'],
     fileLoaderExtensions: [

--- a/test/__snapshots__/create-webpack-config-base.test.js.snap
+++ b/test/__snapshots__/create-webpack-config-base.test.js.snap
@@ -8,8 +8,28 @@ Object {
   "module": Object {
     "rules": Array [
       Object {
-        "exclude": /node_modules\\\\/!\\(@mapbox\\\\/batfish\\\\/\\)/,
-        "test": /\\\\\\.jsx\\?\\$/,
+        "resource": Object {
+          "or": Array [
+            Object {
+              "exclude": /\\[\\\\/\\\\\\\\\\\\\\\\\\]node_modules\\[\\\\/\\\\\\\\\\\\\\\\\\]/,
+              "test": /\\\\\\.jsx\\?\\$/,
+            },
+            Object {
+              "and": Array [
+                Object {
+                  "test": /\\\\\\.jsx\\?\\$/,
+                },
+                Object {
+                  "or": Array [
+                    Object {
+                      "include": /@mapbox\\\\/batfish\\\\/\\(\\?!\\\\/node_modules\\)\\.\\*/,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
         "use": Array [
           Object {
             "loader": "babel-loader",
@@ -131,8 +151,28 @@ Object {
   "module": Object {
     "rules": Array [
       Object {
-        "exclude": /node_modules\\\\/!\\(@mapbox\\\\/batfish\\\\/\\)/,
-        "test": /\\\\\\.jsx\\?\\$/,
+        "resource": Object {
+          "or": Array [
+            Object {
+              "exclude": /\\[\\\\/\\\\\\\\\\\\\\\\\\]node_modules\\[\\\\/\\\\\\\\\\\\\\\\\\]/,
+              "test": /\\\\\\.jsx\\?\\$/,
+            },
+            Object {
+              "and": Array [
+                Object {
+                  "test": /\\\\\\.jsx\\?\\$/,
+                },
+                Object {
+                  "or": Array [
+                    Object {
+                      "include": /@mapbox\\\\/batfish\\\\/\\(\\?!\\\\/node_modules\\)\\.\\*/,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
         "use": Array [
           Object {
             "loader": "babel-loader",
@@ -255,8 +295,37 @@ Object {
   "module": Object {
     "rules": Array [
       Object {
-        "exclude": /node_modules\\\\/nothing/,
-        "test": /\\\\\\.jsx\\?\\$/,
+        "resource": Object {
+          "or": Array [
+            Object {
+              "exclude": /node_modules\\\\/nothing/,
+              "test": /\\\\\\.jsx\\?\\$/,
+            },
+            Object {
+              "and": Array [
+                Object {
+                  "test": /\\\\\\.jsx\\?\\$/,
+                },
+                Object {
+                  "or": Array [
+                    Object {
+                      "include": /@mapbox\\\\/batfish\\\\/\\(\\?!\\\\/node_modules\\)\\.\\*/,
+                    },
+                    Object {
+                      "include": /p-queue\\(\\?!\\\\/node_modules\\)\\.\\*/,
+                    },
+                    Object {
+                      "include": Object {
+                        "exclude": "/foo/bar",
+                        "include": "/foo",
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
         "use": Array [
           Object {
             "loader": "babel-loader",

--- a/test/__snapshots__/create-webpack-config-base.test.js.snap
+++ b/test/__snapshots__/create-webpack-config-base.test.js.snap
@@ -15,7 +15,7 @@ Object {
             "loader": "babel-loader",
             "options": Object {
               "babelrc": false,
-              "cacheDirectory": "<PROJECT_ROOT>/babel-cache",
+              "cacheDirectory": true,
               "compact": true,
               "plugins": "mock-babe-plugins",
               "presets": "mock-babel-presets",
@@ -30,7 +30,7 @@ Object {
             "loader": "babel-loader",
             "options": Object {
               "babelrc": false,
-              "cacheDirectory": "<PROJECT_ROOT>/babel-cache",
+              "cacheDirectory": true,
               "compact": true,
               "plugins": "mock-babe-plugins",
               "presets": "mock-babel-presets",
@@ -63,7 +63,7 @@ Object {
             "loader": "babel-loader",
             "options": Object {
               "babelrc": false,
-              "cacheDirectory": "<PROJECT_ROOT>/babel-cache",
+              "cacheDirectory": true,
               "compact": true,
               "plugins": "mock-babe-plugins",
               "presets": "mock-babel-presets",
@@ -262,7 +262,7 @@ Object {
             "loader": "babel-loader",
             "options": Object {
               "babelrc": false,
-              "cacheDirectory": "<PROJECT_ROOT>/babel-cache",
+              "cacheDirectory": true,
               "compact": true,
               "plugins": "mock-babe-plugins",
               "presets": "mock-babel-presets",
@@ -277,7 +277,7 @@ Object {
             "loader": "babel-loader",
             "options": Object {
               "babelrc": false,
-              "cacheDirectory": "<PROJECT_ROOT>/babel-cache",
+              "cacheDirectory": true,
               "compact": true,
               "plugins": "mock-babe-plugins",
               "presets": "mock-babel-presets",
@@ -316,7 +316,7 @@ Object {
             "loader": "babel-loader",
             "options": Object {
               "babelrc": false,
-              "cacheDirectory": "<PROJECT_ROOT>/babel-cache",
+              "cacheDirectory": true,
               "compact": true,
               "plugins": "mock-babe-plugins",
               "presets": "mock-babel-presets",

--- a/test/__snapshots__/validate-config.test.js.snap
+++ b/test/__snapshots__/validate-config.test.js.snap
@@ -3,7 +3,8 @@
 exports[`validateConfig defaults 1`] = `
 Object {
   "applicationWrapperPath": "<PROJECT_ROOT>/src/webpack/empty-application-wrapper.js",
-  "babelExclude": /node_modules\\\\/!\\(@mapbox\\\\/batfish\\\\/\\)/,
+  "babelExclude": /\\[\\\\/\\\\\\\\\\\\\\\\\\]node_modules\\[\\\\/\\\\\\\\\\\\\\\\\\]/,
+  "babelInclude": Array [],
   "babelPlugins": Array [],
   "babelPresets": Array [],
   "browserslist": Array [

--- a/test/create-webpack-config-base.test.js
+++ b/test/create-webpack-config-base.test.js
@@ -102,6 +102,7 @@ describe('createWebpackConfigBase', () => {
       siteBasePath: '/site/base/path/',
       verbose: true,
       babelExclude: /node_modules\/nothing/,
+      babelInclude: ['p-queue', { include: '/foo', exclude: '/foo/bar' }],
       webpackLoaders: [
         {
           test: /\.jpg$/,


### PR DESCRIPTION
Also includes a very tiny commit for using `babel-loader`'s default location.

@elifitch for review.

I'd love your input on the `babelInclude` decisions. In #218 I was thinking of adding `compileConditions` and `compileNodeModules`, but after thinking more I decided I'd just add a `babelInclude` option and that would cover the use cases.

You'll end up with a [`Rule.resource`](https://webpack.js.org/configuration/module/#rule-resource) for the JS-related Babel compilation that should:

- Accept `.js(x)` files outside of `node_modules`.
- Accept `.js(x)` files inside `node_modules/@mapbox/batfish`.
- Accept `.js(x)` files that *also* match whatever conditions you pass into `babelInclude`.
- Reject everything else.

I hope that the docs I added to `configuration.md` explain how you can use this. Please let me know if they need more work!

The way I verified that this was working as expected was by messing with the basic demo, adding `p-queue` and `p-throttle` as dependencies (which are published with ES2015 code), varying the `babelInclude` option, and checking out the output files in `_batfish_site` to see if they still included `class` keywords and arrow functions.