### PR TITLE
Client-side Webpack sets core Node libraries to "empty"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## HEAD
+
+- **Add:** Use Webpack's `node` option in the client config to stub core Node libraries, resulting in fewer errors buried in users' dependencies.
+
 ## 1.3.0
 
 - **Add:** Add `devBrowserslist` option. **This will change the browser support of your development (not production) build.**

--- a/src/node/create-webpack-config-client.js
+++ b/src/node/create-webpack-config-client.js
@@ -167,7 +167,15 @@ function createWebpackConfigClient(
         })
       },
       target: 'web',
-      plugins: clientPlugins
+      plugins: clientPlugins,
+      // This helps us import more libraries with fewer errors.
+      node: {
+        dgram: 'empty',
+        fs: 'empty',
+        net: 'empty',
+        tls: 'empty',
+        child_process: 'empty'
+      }
     };
 
     let config = webpackMerge(baseConfig, clientConfig);

--- a/src/node/create-webpack-config-static.js
+++ b/src/node/create-webpack-config-static.js
@@ -42,6 +42,7 @@ function createWebpackConfigStatic(
         new webpack.optimize.LimitChunkCountPlugin({ maxChunks: 1 })
       ],
       devtool: 'source-map',
+      // Don't hijack Node's globals: this code will execute in Node.
       node: {
         console: false,
         global: false,

--- a/test/__snapshots__/create-webpack-config-client.test.js.snap
+++ b/test/__snapshots__/create-webpack-config-client.test.js.snap
@@ -16,6 +16,13 @@ Object {
       "<PROJECT_ROOT>/node_modules/@mapbox/link-hijacker/index.js",
     ],
   },
+  "node": Object {
+    "child_process": "empty",
+    "dgram": "empty",
+    "fs": "empty",
+    "net": "empty",
+    "tls": "empty",
+  },
   "output": Object {
     "chunkFilename": "[name].chunk.js",
     "filename": "[name].js",
@@ -113,6 +120,13 @@ Object {
       "<PROJECT_ROOT>/node_modules/@mapbox/scroll-restorer/index.js",
       "<PROJECT_ROOT>/node_modules/@mapbox/link-hijacker/index.js",
     ],
+  },
+  "node": Object {
+    "child_process": "empty",
+    "dgram": "empty",
+    "fs": "empty",
+    "net": "empty",
+    "tls": "empty",
   },
   "output": Object {
     "chunkFilename": "[name]-[chunkhash].chunk.js",
@@ -234,6 +248,13 @@ Object {
       "pigman",
       "revenge-of-pigman",
     ],
+  },
+  "node": Object {
+    "child_process": "empty",
+    "dgram": "empty",
+    "fs": "empty",
+    "net": "empty",
+    "tls": "empty",
   },
   "output": Object {
     "chunkFilename": "[name].chunk.js",


### PR DESCRIPTION
This allows the user to import more dependencies with fewer
errors. A dependency can import a library like "fs" without
an error -- the error will only come if they try to use the
library within the code that the user's app ends up executing.

Closes #241.