### PR TITLE
Remove webpack-chunk-hash dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## HEAD
+
+- Remove webpack-chunk-hash dependency. Recent versions of Webpack do not require this module for deterministic filename hashing.
+
 ## 1.5.0
 
 - **Add:** Add `staticHtmlInlineDeferCss` option.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/batfish",
-  "version": "1.3.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -420,34 +420,6 @@
       "version": "6.0.85",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.85.tgz",
       "integrity": "sha512-6qLZpfQFO/g5Ns2e7RsW6brk0Q6Xzwiw7kVVU/XiQNOiJXSojhX76GP457PBYIsNMH2WfcGgcnZB4awFDHrwpA=="
-    },
-    "@types/source-map": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@types/source-map/-/source-map-0.5.1.tgz",
-      "integrity": "sha512-/GVAjL1Y8puvZab63n8tsuBiYwZt1bApMdx58/msQ9ID5T05ov+wm/ZV1DvYC/DKKEygpTJViqQvkh5Rhrl4CA=="
-    },
-    "@types/tapable": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-0.2.4.tgz",
-      "integrity": "sha512-pclMAvhPnXJcJu1ZZ8bQthuUcdDWzDuxDdbSf6l1U6s4fP6EBiZpPsOZYqFOrbqDV97sXGFSsb6AUpiLfv4xIA=="
-    },
-    "@types/uglify-js": {
-      "version": "2.6.29",
-      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-2.6.29.tgz",
-      "integrity": "sha512-BdFLCZW0GTl31AbqXSak8ss/MqEZ3DN2MH9rkAyGoTuzK7ifGUlX+u0nfbWeTsa7IPcZhtn8BlpYBXSV+vqGhQ==",
-      "requires": {
-        "@types/source-map": "0.5.1"
-      }
-    },
-    "@types/webpack": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-3.0.13.tgz",
-      "integrity": "sha512-gWVIAVaGapOPHOrjUQalUqdJWdUIn8w5gpKzz2L14megpB1euvq4HxvGusp9nhtkYGjD/sIg20Zse42b7+7BDw==",
-      "requires": {
-        "@types/node": "6.0.85",
-        "@types/tapable": "0.2.4",
-        "@types/uglify-js": "2.6.29"
-      }
     },
     "abab": {
       "version": "1.0.4",
@@ -17849,14 +17821,6 @@
             }
           }
         }
-      }
-    },
-    "webpack-chunk-hash": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/webpack-chunk-hash/-/webpack-chunk-hash-0.5.0.tgz",
-      "integrity": "sha1-Hbo4ID1zwearBptoEKWjdAI5new=",
-      "requires": {
-        "@types/webpack": "3.0.13"
       }
     },
     "webpack-format-messages": {

--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
     "uglify-js": "^3.3.15",
     "uglifyjs-webpack-plugin": "^1.2.4",
     "webpack": "^3.11.0",
-    "webpack-chunk-hash": "^0.5.0",
     "webpack-format-messages": "^1.0.2",
     "webpack-merge": "^4.1.2",
     "worker-farm": "^1.6.0"

--- a/src/node/create-webpack-config-base.js
+++ b/src/node/create-webpack-config-base.js
@@ -4,7 +4,6 @@
 const _ = require('lodash');
 const path = require('path');
 const webpack = require('webpack');
-const WebpackChunkHash = require('webpack-chunk-hash');
 const writeContextModule = require('./write-context-module');
 const joinUrlParts = require('./join-url-parts');
 const constants = require('./constants');
@@ -188,10 +187,7 @@ function createWebpackConfigBase(
           'process.env.NODE_ENV': !batfishConfig.production
             ? '"development"'
             : '"production"'
-        }),
-        // Determine hashes with file content, not random strings. This allows
-        // for long-term caching.
-        new WebpackChunkHash()
+        })
       ],
       // Designate sourcemap type.
       devtool: !batfishConfig.production

--- a/test/__snapshots__/create-webpack-config-base.test.js.snap
+++ b/test/__snapshots__/create-webpack-config-base.test.js.snap
@@ -118,11 +118,6 @@ Object {
         "process.env.NODE_ENV": "\\"development\\"",
       },
     },
-    WebpackChunkHash {
-      "additionalHashContent": [Function],
-      "algorithm": "md5",
-      "digest": "hex",
-    },
   ],
   "resolve": Object {
     "alias": Object {
@@ -261,11 +256,6 @@ Object {
       "definitions": Object {
         "process.env.NODE_ENV": "\\"production\\"",
       },
-    },
-    WebpackChunkHash {
-      "additionalHashContent": [Function],
-      "algorithm": "md5",
-      "digest": "hex",
     },
   ],
   "resolve": Object {
@@ -427,11 +417,6 @@ Object {
       "definitions": Object {
         "process.env.NODE_ENV": "\\"development\\"",
       },
-    },
-    WebpackChunkHash {
-      "additionalHashContent": [Function],
-      "algorithm": "md5",
-      "digest": "hex",
     },
   ],
   "resolve": Object {


### PR DESCRIPTION
Recent versions of Webpack do not require this module for
deterministic filename hashing.