### PR TITLE
Include data about headings in Markdown pages for ToC generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD
 
+- **Add:** Automatically add data about headings to front matter of Markdown pages and `id` attributes to the heading elements.
+  The headings data can be used to generate a table of contents in the Markdown page wrapper component, as illustrated in the table-of-contents example.
+  (This feature was added to jsxtreme-markdown.)
 - Chore: Unobtrusive dependency updates.
 
 ## 1.7.5

--- a/README.md
+++ b/README.md
@@ -289,7 +289,11 @@ Things had started to smell ...
 I love shopping for cleaning supplies ...
 ```
 
-See [`examples/miscellany/`](examples/miscellany) to learn more about what's possible with Markdown wrappers.
+The front matter passed to Markdown wrapper components is augmented with a `headings` field, which contains an array of data about the headings in the Markdown.
+This data includes `slug`s that correspond to `id` attributes automatically added to the heading elements; so you can use this to generate a table of contents.
+(Read more in ["Generating tables of contents for Markdown pages"].)
+
+See [`examples/miscellany/`](examples/miscellany) and [`examples/table-of-contents/`](examples/table-of-contents) to learn more about what's possible with Markdown wrappers.
 
 #### Import JS modules into jsxtreme-markdown
 
@@ -473,3 +477,5 @@ Please let us know what you think!
 ["page-specific css"]: docs/advanced-usage.md#page-specific-css
 
 ["hello world guide"]: docs/hello-world.md
+
+["generating tables of contents for markdown pages"]: docs/advanced-usage.md#generating-tables-of-contents-for-markdown-pages

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -14,6 +14,7 @@
 - [Route change listeners](#route-change-listeners)
 - [Analyzing bundles](#analyzing-bundles)
 - [Page-specific CSS](#page-specific-css)
+- [Generating tables of contents for Markdown pages](#generating-tables-of-contents-for-markdown-pages)
 
 ## Draft pages
 
@@ -297,6 +298,22 @@ export default class SomePage extends React.Component {
 
 **You can turn this behavior off if you have your own preferences about what to do with imported `.css` files.**
 Set the [`pageSpecificCss`] option to `false`.
+
+## Generating tables of contents for Markdown pages
+
+The front matter of Markdown pages is automatically augmented with a `headings` property that includes data about the headings in the Markdown file.
+(This is [a feature of jsxtreme-markdown](https://github.com/mapbox/jsxtreme-markdown/tree/master/packages/jsxtreme-markdown#headings).)
+
+You can use this data in your Markdown wrapper to automatically generate a table of contents!
+The value `headings` is an an array of objects; each object has the following properties:
+
+- `text`: the text of the heading.
+- `slug`: the slugified heading text, which corresponds to an `id` attribute automatically added to the heading elements.
+  Use this to create hash fragment links, e.g. `<a href={`#${item.slug}`}>`.
+- `level`: the level of the heading (1-6).
+
+Use regular JS methods like `filter`, `map`, etc., to transform the provided data structure into the table of contents of your dreams.
+For example, [`examples/table-of-contents/`](../examples/table-of-contents) includes a Markdown wrapper that creates a table of contents that only displays headings of levels 2 and 3 and indents level 3 headings.
 
 [`route-change-listeners`]: ./batfish-modules.md#route-change-listeners
 

--- a/examples/table-of-contents/README.md
+++ b/examples/table-of-contents/README.md
@@ -1,0 +1,6 @@
+# Table of contents
+
+- Uses `headings` in Markdown pages' front matter to create a table of contents.
+  Read more about this technique in ["Generating tables of contents for Markdown pages"].
+
+["Generating tables of contents for Markdown pages"]: ../docs/advanced-usage.md#generating-tables-of-contents-for-markdown-pages

--- a/examples/table-of-contents/batfish.config.js
+++ b/examples/table-of-contents/batfish.config.js
@@ -1,0 +1,9 @@
+const path = require('path');
+
+module.exports = () => {
+  return {
+    jsxtremeMarkdownOptions: {
+      wrapper: path.join(__dirname, './src/components/markdown-wrapper.js')
+    }
+  };
+};

--- a/examples/table-of-contents/package.json
+++ b/examples/table-of-contents/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "scripts": {
+    "batfish": "../../bin/example-batfish"
+  },
+  "dependencies": {}
+}

--- a/examples/table-of-contents/src/components/markdown-wrapper.js
+++ b/examples/table-of-contents/src/components/markdown-wrapper.js
@@ -1,0 +1,32 @@
+import React from 'react';
+
+export default class MarkdownWrapper extends React.Component {
+  renderToc() {
+    const { headings } = this.props.frontMatter;
+    if (!headings) return null;
+    const entries = headings
+      .filter(heading => {
+        return heading.level > 1 && heading.level < 4;
+      })
+      .map(heading => {
+        const linkStyle = { marginLeft: 20 * (heading.level - 2) };
+        return (
+          <li key={heading.slug}>
+            <a href={`#${heading.slug}`} style={linkStyle}>
+              {heading.text}
+            </a>
+          </li>
+        );
+      });
+    return <ul>{entries}</ul>;
+  }
+  render() {
+    return (
+      <div>
+        <h1>{this.props.frontMatter.title}</h1>
+        {this.renderToc()}
+        {this.props.children}
+      </div>
+    );
+  }
+}

--- a/examples/table-of-contents/src/pages/index.md
+++ b/examples/table-of-contents/src/pages/index.md
@@ -1,0 +1,43 @@
+---
+title: Main page title
+---
+
+## First section
+
+Fusce gravida erat quis enim eleifend accumsan at in quam. Vivamus feugiat eleifend tortor, eu maximus ipsum sollicitudin et. Nunc porta nisl a aliquet aliquam. Nulla tempus condimentum justo, a sodales turpis lacinia ut. Fusce est ex, egestas non magna tincidunt, porttitor consectetur nisl. Vivamus tempor accumsan ligula sagittis posuere. Pellentesque sed dignissim orci. Phasellus mattis eget turpis pellentesque malesuada. Aliquam euismod diam ut nibh vestibulum, ut convallis lectus interdum. Donec vulputate elit ut nisl euismod, in pulvinar orci porta.
+
+Suspendisse accumsan metus quis nibh posuere cursus. Donec nec cursus nunc. Phasellus sodales sem vel convallis ornare. Nulla lacinia arcu eu metus vestibulum malesuada. Mauris quam lectus, iaculis at ligula eget, commodo faucibus magna. Cras viverra elementum lorem quis commodo. In hac habitasse platea dictumst. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Aliquam erat volutpat. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+Nulla at orci est. Etiam auctor, justo vitae vulputate mattis, lacus est vehicula lorem, quis malesuada lectus odio eu orci. Maecenas condimentum orci ut massa dictum, sed rutrum quam maximus. Sed consequat elit sed justo condimentum placerat sit amet sit amet est. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Mauris eu ultricies magna. Nullam facilisis est mi, ac volutpat erat luctus id.
+
+Donec sed imperdiet tellus. Aliquam a nunc nec ligula luctus ornare. Praesent sagittis ex vel felis tincidunt placerat. Morbi iaculis nibh enim, et ultricies justo varius ac. Pellentesque malesuada elit eu lacus dapibus, quis elementum ante iaculis. Quisque vel sem et dui tristique pharetra vel vel neque. Cras at massa non mi rutrum congue ac quis magna. Praesent nec aliquam erat. Cras interdum tristique risus quis congue. Aliquam erat volutpat. Maecenas bibendum nunc at nibh interdum, nec ultrices odio accumsan. Cras at felis congue, pulvinar nulla ut, porttitor mi.
+
+### Second section
+
+Fusce gravida erat quis enim eleifend accumsan at in quam. Vivamus feugiat eleifend tortor, eu maximus ipsum sollicitudin et. Nunc porta nisl a aliquet aliquam. Nulla tempus condimentum justo, a sodales turpis lacinia ut. Fusce est ex, egestas non magna tincidunt, porttitor consectetur nisl. Vivamus tempor accumsan ligula sagittis posuere. Pellentesque sed dignissim orci. Phasellus mattis eget turpis pellentesque malesuada. Aliquam euismod diam ut nibh vestibulum, ut convallis lectus interdum. Donec vulputate elit ut nisl euismod, in pulvinar orci porta.
+
+Suspendisse accumsan metus quis nibh posuere cursus. Donec nec cursus nunc. Phasellus sodales sem vel convallis ornare. Nulla lacinia arcu eu metus vestibulum malesuada. Mauris quam lectus, iaculis at ligula eget, commodo faucibus magna. Cras viverra elementum lorem quis commodo. In hac habitasse platea dictumst. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Aliquam erat volutpat. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+Nulla at orci est. Etiam auctor, justo vitae vulputate mattis, lacus est vehicula lorem, quis malesuada lectus odio eu orci. Maecenas condimentum orci ut massa dictum, sed rutrum quam maximus. Sed consequat elit sed justo condimentum placerat sit amet sit amet est. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Mauris eu ultricies magna. Nullam facilisis est mi, ac volutpat erat luctus id.
+
+Donec sed imperdiet tellus. Aliquam a nunc nec ligula luctus ornare. Praesent sagittis ex vel felis tincidunt placerat. Morbi iaculis nibh enim, et ultricies justo varius ac. Pellentesque malesuada elit eu lacus dapibus, quis elementum ante iaculis. Quisque vel sem et dui tristique pharetra vel vel neque. Cras at massa non mi rutrum congue ac quis magna. Praesent nec aliquam erat. Cras interdum tristique risus quis congue. Aliquam erat volutpat. Maecenas bibendum nunc at nibh interdum, nec ultrices odio accumsan. Cras at felis congue, pulvinar nulla ut, porttitor mi.
+
+### Third section
+
+Fusce gravida erat quis enim eleifend accumsan at in quam. Vivamus feugiat eleifend tortor, eu maximus ipsum sollicitudin et. Nunc porta nisl a aliquet aliquam. Nulla tempus condimentum justo, a sodales turpis lacinia ut. Fusce est ex, egestas non magna tincidunt, porttitor consectetur nisl. Vivamus tempor accumsan ligula sagittis posuere. Pellentesque sed dignissim orci. Phasellus mattis eget turpis pellentesque malesuada. Aliquam euismod diam ut nibh vestibulum, ut convallis lectus interdum. Donec vulputate elit ut nisl euismod, in pulvinar orci porta.
+
+Suspendisse accumsan metus quis nibh posuere cursus. Donec nec cursus nunc. Phasellus sodales sem vel convallis ornare. Nulla lacinia arcu eu metus vestibulum malesuada. Mauris quam lectus, iaculis at ligula eget, commodo faucibus magna. Cras viverra elementum lorem quis commodo. In hac habitasse platea dictumst. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Aliquam erat volutpat. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+Nulla at orci est. Etiam auctor, justo vitae vulputate mattis, lacus est vehicula lorem, quis malesuada lectus odio eu orci. Maecenas condimentum orci ut massa dictum, sed rutrum quam maximus. Sed consequat elit sed justo condimentum placerat sit amet sit amet est. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Mauris eu ultricies magna. Nullam facilisis est mi, ac volutpat erat luctus id.
+
+Donec sed imperdiet tellus. Aliquam a nunc nec ligula luctus ornare. Praesent sagittis ex vel felis tincidunt placerat. Morbi iaculis nibh enim, et ultricies justo varius ac. Pellentesque malesuada elit eu lacus dapibus, quis elementum ante iaculis. Quisque vel sem et dui tristique pharetra vel vel neque. Cras at massa non mi rutrum congue ac quis magna. Praesent nec aliquam erat. Cras interdum tristique risus quis congue. Aliquam erat volutpat. Maecenas bibendum nunc at nibh interdum, nec ultrices odio accumsan. Cras at felis congue, pulvinar nulla ut, porttitor mi.
+
+## Fourth  section
+
+Fusce gravida erat quis enim eleifend accumsan at in quam. Vivamus feugiat eleifend tortor, eu maximus ipsum sollicitudin et. Nunc porta nisl a aliquet aliquam. Nulla tempus condimentum justo, a sodales turpis lacinia ut. Fusce est ex, egestas non magna tincidunt, porttitor consectetur nisl. Vivamus tempor accumsan ligula sagittis posuere. Pellentesque sed dignissim orci. Phasellus mattis eget turpis pellentesque malesuada. Aliquam euismod diam ut nibh vestibulum, ut convallis lectus interdum. Donec vulputate elit ut nisl euismod, in pulvinar orci porta.
+
+Suspendisse accumsan metus quis nibh posuere cursus. Donec nec cursus nunc. Phasellus sodales sem vel convallis ornare. Nulla lacinia arcu eu metus vestibulum malesuada. Mauris quam lectus, iaculis at ligula eget, commodo faucibus magna. Cras viverra elementum lorem quis commodo. In hac habitasse platea dictumst. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Aliquam erat volutpat. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+Nulla at orci est. Etiam auctor, justo vitae vulputate mattis, lacus est vehicula lorem, quis malesuada lectus odio eu orci. Maecenas condimentum orci ut massa dictum, sed rutrum quam maximus. Sed consequat elit sed justo condimentum placerat sit amet sit amet est. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Mauris eu ultricies magna. Nullam facilisis est mi, ac volutpat erat luctus id.
+
+Donec sed imperdiet tellus. Aliquam a nunc nec ligula luctus ornare. Praesent sagittis ex vel felis tincidunt placerat. Morbi iaculis nibh enim, et ultricies justo varius ac. Pellentesque malesuada elit eu lacus dapibus, quis elementum ante iaculis. Quisque vel sem et dui tristique pharetra vel vel neque. Cras at massa non mi rutrum congue ac quis magna. Praesent nec aliquam erat. Cras interdum tristique risus quis congue. Aliquam erat volutpat. Maecenas bibendum nunc at nibh interdum, nec ultrices odio accumsan. Cras at felis congue, pulvinar nulla ut, porttitor mi.

--- a/flow-typed/defs.js
+++ b/flow-typed/defs.js
@@ -38,7 +38,8 @@ declare type BatfishConfiguration = {
   jsxtremeMarkdownOptions: {
     prependJs?: Array<string>,
     remarkPlugins?: Array<Function>,
-    rehypePlugins?: Array<Function>
+    rehypePlugins?: Array<Function>,
+    headings?: boolean
   },
   includePromisePolyfill: boolean,
   inlineJs?: Array<InlineJsEntry>,

--- a/package-lock.json
+++ b/package-lock.json
@@ -180,11 +180,11 @@
       }
     },
     "@mapbox/babel-plugin-transform-jsxtreme-markdown": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@mapbox/babel-plugin-transform-jsxtreme-markdown/-/babel-plugin-transform-jsxtreme-markdown-0.4.3.tgz",
-      "integrity": "sha512-Gn4T2aMhy/V5YiChAAE1DMPfi1UOUNTX5q0vzUMkRN6TsZuHQne0Lxfnplkoc2GEEzA5yQ7z6mvDVYD8w3ea8w==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/babel-plugin-transform-jsxtreme-markdown/-/babel-plugin-transform-jsxtreme-markdown-0.4.4.tgz",
+      "integrity": "sha512-q3fJQuIU5UCnbykHkRlmO/et7ohwHgUqpxwrrXc0hJOneKl+YZeL/8ozH7xr2PjzN1mLU5K2FI0fCDHIX2AU+A==",
       "requires": {
-        "@mapbox/jsxtreme-markdown": "0.7.4",
+        "@mapbox/jsxtreme-markdown": "0.8.0",
         "babylon": "6.18.0"
       },
       "dependencies": {
@@ -195,11 +195,30 @@
         }
       }
     },
-    "@mapbox/jsxtreme-markdown": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@mapbox/jsxtreme-markdown/-/jsxtreme-markdown-0.7.4.tgz",
-      "integrity": "sha512-9sWzVjLOVtNDmOk5kCZwBiqX+miTv5lL6VoRdit7ZmlvkivXMMnDHtusriz2nv7ED2SaBunOzP4xEKGdbLvrtw==",
+    "@mapbox/hast-util-table-cell-style": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/hast-util-table-cell-style/-/hast-util-table-cell-style-0.1.2.tgz",
+      "integrity": "sha512-xb6zAci9TVWFB1iGEf+Uyl30Sw7LKCAnf1xhCGc8xHdSQ/oxXgMhgLFWiRTL0Rv0sQhsTmzB37fmpnOlIfFPTw==",
       "requires": {
+        "unist-util-visit": "1.3.0"
+      },
+      "dependencies": {
+        "unist-util-visit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.0.tgz",
+          "integrity": "sha512-9ntYcxPFtl44gnwXrQKZ5bMqXMY0ZHzUpqMFiU4zcc8mmf/jzYm8GhYgezuUlX4cJIM1zIDYaO6fG/fI+L6iiQ==",
+          "requires": {
+            "unist-util-is": "2.1.1"
+          }
+        }
+      }
+    },
+    "@mapbox/jsxtreme-markdown": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsxtreme-markdown/-/jsxtreme-markdown-0.8.0.tgz",
+      "integrity": "sha512-ImZgdbqeUQMJxyTnrKHSxEiQLNKuwBX7QBKEV0hnsvpq1HxJ2yoPEK00BzB8VrkRI6Nm9d1Uz+qvmEqTda/6Rg==",
+      "requires": {
+        "@mapbox/hast-util-table-cell-style": "0.1.2",
         "babel-code-frame": "6.26.0",
         "babel-core": "6.26.0",
         "babel-preset-env": "1.6.1",
@@ -207,9 +226,11 @@
         "balanced-match": "1.0.0",
         "block-elements": "1.2.0",
         "front-matter": "2.3.0",
+        "github-slugger": "1.2.0",
         "htmltojsx": "0.2.6",
         "line-column": "1.0.2",
         "lodash": "4.17.5",
+        "mdast-util-to-string": "1.0.4",
         "pascal-case": "2.0.1",
         "prettier": "1.11.1",
         "rehype-raw": "2.0.0",
@@ -217,7 +238,8 @@
         "remark-parse": "5.0.0",
         "remark-rehype": "3.0.0",
         "stringify-object": "3.2.2",
-        "unified": "6.1.6"
+        "unified": "6.1.6",
+        "unist-util-visit": "1.3.0"
       },
       "dependencies": {
         "babel-code-frame": {
@@ -240,6 +262,14 @@
             "has-ansi": "2.0.0",
             "strip-ansi": "3.0.1",
             "supports-color": "2.0.0"
+          }
+        },
+        "github-slugger": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.2.0.tgz",
+          "integrity": "sha512-wIaa75k1vZhyPm9yWrD08A5Xnx/V+RmzGrpjQuLemGKSb77Qukiaei58Bogrl/LZSADDfPzKJX8jhLs4CRTl7Q==",
+          "requires": {
+            "emoji-regex": "6.1.1"
           }
         },
         "remark-parse": {
@@ -285,17 +315,138 @@
             "x-is-function": "1.0.4",
             "x-is-string": "0.1.0"
           }
+        },
+        "unist-util-visit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.0.tgz",
+          "integrity": "sha512-9ntYcxPFtl44gnwXrQKZ5bMqXMY0ZHzUpqMFiU4zcc8mmf/jzYm8GhYgezuUlX4cJIM1zIDYaO6fG/fI+L6iiQ==",
+          "requires": {
+            "unist-util-is": "2.1.1"
+          }
         }
       }
     },
     "@mapbox/jsxtreme-markdown-loader": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@mapbox/jsxtreme-markdown-loader/-/jsxtreme-markdown-loader-0.5.4.tgz",
-      "integrity": "sha512-aChBF2L0Fo+iBvLqMwkw50uAd7RctQWgL0A5WPBNuFVKRrSjzGtoYZlc5tnFUeixkqxAQ+D4nNx16F8dzutP6w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsxtreme-markdown-loader/-/jsxtreme-markdown-loader-0.6.0.tgz",
+      "integrity": "sha512-WvIZ4tueO/kPZx/OTmMYlpl5eQ9nRPT4FnPcwe9sAKjgJdficPIkcmQnvDf+1prAXGACg0BAbogvyhdGd2sQkw==",
       "requires": {
-        "@mapbox/jsxtreme-markdown": "0.7.4",
+        "@mapbox/jsxtreme-markdown": "0.8.0",
         "loader-utils": "1.1.0",
         "lodash.clonedeep": "4.5.0"
+      },
+      "dependencies": {
+        "@mapbox/jsxtreme-markdown": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/@mapbox/jsxtreme-markdown/-/jsxtreme-markdown-0.8.0.tgz",
+          "integrity": "sha512-ImZgdbqeUQMJxyTnrKHSxEiQLNKuwBX7QBKEV0hnsvpq1HxJ2yoPEK00BzB8VrkRI6Nm9d1Uz+qvmEqTda/6Rg==",
+          "requires": {
+            "@mapbox/hast-util-table-cell-style": "0.1.2",
+            "babel-code-frame": "6.26.0",
+            "babel-core": "6.26.0",
+            "babel-preset-env": "1.6.1",
+            "babel-preset-react": "6.24.1",
+            "balanced-match": "1.0.0",
+            "block-elements": "1.2.0",
+            "front-matter": "2.3.0",
+            "github-slugger": "1.2.0",
+            "htmltojsx": "0.2.6",
+            "line-column": "1.0.2",
+            "lodash": "4.17.5",
+            "mdast-util-to-string": "1.0.4",
+            "pascal-case": "2.0.1",
+            "prettier": "1.11.1",
+            "rehype-raw": "2.0.0",
+            "rehype-stringify": "3.0.0",
+            "remark-parse": "5.0.0",
+            "remark-rehype": "3.0.0",
+            "stringify-object": "3.2.2",
+            "unified": "6.1.6",
+            "unist-util-visit": "1.3.0"
+          }
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+          "requires": {
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "github-slugger": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.2.0.tgz",
+          "integrity": "sha512-wIaa75k1vZhyPm9yWrD08A5Xnx/V+RmzGrpjQuLemGKSb77Qukiaei58Bogrl/LZSADDfPzKJX8jhLs4CRTl7Q==",
+          "requires": {
+            "emoji-regex": "6.1.1"
+          }
+        },
+        "remark-parse": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
+          "integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
+          "requires": {
+            "collapse-white-space": "1.0.3",
+            "is-alphabetical": "1.0.1",
+            "is-decimal": "1.0.1",
+            "is-whitespace-character": "1.0.1",
+            "is-word-character": "1.0.1",
+            "markdown-escapes": "1.0.1",
+            "parse-entities": "1.1.1",
+            "repeat-string": "1.6.1",
+            "state-toggle": "1.0.0",
+            "trim": "0.0.1",
+            "trim-trailing-lines": "1.1.0",
+            "unherit": "1.1.0",
+            "unist-util-remove-position": "1.1.1",
+            "vfile-location": "2.0.2",
+            "xtend": "4.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "unified": {
+          "version": "6.1.6",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-6.1.6.tgz",
+          "integrity": "sha512-pW2f82bCIo2ifuIGYcV12fL96kMMYgw7JKVEgh7ODlrM9rj6vXSY3BV+H6lCcv1ksxynFf582hwWLnA1qRFy4w==",
+          "requires": {
+            "bail": "1.0.2",
+            "extend": "3.0.1",
+            "is-plain-obj": "1.1.0",
+            "trough": "1.0.1",
+            "vfile": "2.2.0",
+            "x-is-function": "1.0.4",
+            "x-is-string": "0.1.0"
+          }
+        },
+        "unist-util-visit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.0.tgz",
+          "integrity": "sha512-9ntYcxPFtl44gnwXrQKZ5bMqXMY0ZHzUpqMFiU4zcc8mmf/jzYm8GhYgezuUlX4cJIM1zIDYaO6fG/fI+L6iiQ==",
+          "requires": {
+            "unist-util-is": "2.1.1"
+          }
+        }
       }
     },
     "@mapbox/link-hijacker": {
@@ -4237,8 +4388,7 @@
     "emoji-regex": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
-      "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4=",
-      "dev": true
+      "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4="
     },
     "emojis-list": {
       "version": "2.1.0",
@@ -11594,8 +11744,7 @@
     "mdast-util-to-string": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.0.4.tgz",
-      "integrity": "sha1-XEVch4yTVfDB5/PotxnPWDaRrPs=",
-      "dev": true
+      "integrity": "sha1-XEVch4yTVfDB5/PotxnPWDaRrPs="
     },
     "mdast-util-toc": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -81,8 +81,8 @@
   },
   "dependencies": {
     "@babel/code-frame": "^7.0.0-beta.42",
-    "@mapbox/babel-plugin-transform-jsxtreme-markdown": "^0.4.3",
-    "@mapbox/jsxtreme-markdown-loader": "^0.5.4",
+    "@mapbox/babel-plugin-transform-jsxtreme-markdown": "^0.4.4",
+    "@mapbox/jsxtreme-markdown-loader": "^0.6.0",
     "@mapbox/link-hijacker": "^1.1.0",
     "@mapbox/link-to-location": "^1.0.0",
     "@mapbox/postcss-html-filter": "^1.0.1",

--- a/src/node/create-webpack-config-base.js
+++ b/src/node/create-webpack-config-base.js
@@ -35,6 +35,9 @@ function createWebpackConfigBase(
       `import { routeTo, routeToPrefixed } from '@mapbox/batfish/modules/route-to';`
     );
     jsxtremeMarkdownOptions.prependJs = prependJs;
+    if (jsxtremeMarkdownOptions.headings === undefined) {
+      jsxtremeMarkdownOptions.headings = true;
+    }
 
     const fileLoaderTest = new RegExp(
       `\\.(${batfishConfig.fileLoaderExtensions.join('|')})$`

--- a/test/__snapshots__/create-webpack-config-base.test.js.snap
+++ b/test/__snapshots__/create-webpack-config-base.test.js.snap
@@ -59,6 +59,7 @@ Object {
           Object {
             "loader": "@mapbox/jsxtreme-markdown-loader",
             "options": Object {
+              "headings": true,
               "prependJs": Array [
                 "import { prefixUrl, prefixUrlAbsolute } from '@mapbox/batfish/modules/prefix-url';",
                 "import { routeTo, routeToPrefixed } from '@mapbox/batfish/modules/route-to';",
@@ -197,6 +198,7 @@ Object {
           Object {
             "loader": "@mapbox/jsxtreme-markdown-loader",
             "options": Object {
+              "headings": true,
               "prependJs": Array [
                 "import { prefixUrl, prefixUrlAbsolute } from '@mapbox/batfish/modules/prefix-url';",
                 "import { routeTo, routeToPrefixed } from '@mapbox/batfish/modules/route-to';",
@@ -345,6 +347,7 @@ Object {
           Object {
             "loader": "@mapbox/jsxtreme-markdown-loader",
             "options": Object {
+              "headings": true,
               "prependJs": Array [
                 "const add = (x, y) => x + y;",
                 "import egg from 'chicken';",


### PR DESCRIPTION
Uses [a new feature of jsxtreme-markdown](https://github.com/mapbox/jsxtreme-markdown/tree/master/packages/jsxtreme-markdown#headings) to automatically include in Markdown page front matter some data about headings that you can use to generate a table of contents in your Markdown wrapper component.

@colleenmcginnis: I'd love a review from you. Mostly I'm just turning on a feature of jsxtreme-markdown, so the changes here are about documentation and exemplification, which pertain to you since you'll be using the feature right away 😄 