### PR TITLE
Better CSS asset filenames and exposing Batfish's version of Webpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## HEAD
 
-- **Fix:** Prevent batfish from entering an unpredictable state if provided port is unavailable.
 - **Feature:** Added a helpful message if the provided port is not available.
+- **Feature:** Files reference as URLs in CSS then copied into the output directory (via postcss-url) now include the file's original basename as well as the hash.
+- **Fix:** Prevent batfish from entering an unpredictable state if provided port is unavailable.
 
 ## 1.8.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **Feature:** Added a helpful message if the provided port is not available.
 - **Feature:** Files reference as URLs in CSS then copied into the output directory (via postcss-url) now include the file's original basename as well as the hash.
+- **Feature:** Expose Batfish's version of Webpack on `require('@mapbox/batfish').webpack`, so it can be used for custom plugin configuration.
 - **Fix:** Prevent batfish from entering an unpredictable state if provided port is unavailable.
 
 ## 1.8.2

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -302,6 +302,22 @@ Type: `Array<Object>`.
 
 Additional plugin configuration to pass to Webpack during the client bundling task.
 
+For plugins exposed on the `webpack` module itself (e.g. `webpack.DefinePlugin`), **you should use Batfish's version of Webpack instead of installing your own.**
+That will prevent any version incompatibilities.
+**The Batfish package exposes its version of Webpack as the `webpack` property of its export.**
+
+Here, for example, is how you could use the `DefinePlugin` in your `batfish.config.js`:
+
+```js
+const batfish = require('@mapbox/batfish');
+
+module.exports = () => {
+  return {
+    webpackPlugins: new batfish.webpack.DefinePlugin(..)
+  };
+}
+```
+
 ### webpackStaticStubReactComponent
 
 Type: `Array<string>`.

--- a/examples/optimizing-loaders/batfish.config.js
+++ b/examples/optimizing-loaders/batfish.config.js
@@ -1,3 +1,4 @@
+const batfish = require('../../dist/node');
 const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 
 module.exports = () => {
@@ -19,7 +20,12 @@ module.exports = () => {
         ]
       }
     ],
-    webpackPlugins: [new LodashModuleReplacementPlugin()],
+    webpackPlugins: [
+      new LodashModuleReplacementPlugin(),
+      new batfish.webpack.DefinePlugin({
+        DEFINED: '"yes"'
+      })
+    ],
     babelPlugins: [require('babel-plugin-lodash')]
   };
 };

--- a/examples/optimizing-loaders/src/pages/index.js
+++ b/examples/optimizing-loaders/src/pages/index.js
@@ -1,3 +1,4 @@
+/* globals DEFINED */
 import React from 'react';
 import _ from 'lodash';
 export default class Home extends React.PureComponent {
@@ -14,11 +15,13 @@ export default class Home extends React.PureComponent {
     return (
       <div>
         <h1>Optimization loaders and plugins</h1>
-
+        Did the DefinePlugin work?{' '}
+        <span style={{ fontWeight: 'bold' }}>
+          {DEFINED === 'yes' ? 'Yes!' : 'No!'}
+        </span>
         <div style={{ marginTop: 30 }}>
           <img src={require('../img/man-in-a-bottle.jpg')} />
         </div>
-
         <div style={{ marginTop: 30 }}>
           The Lodash plugin works if the following does not say "3":{' '}
           <code style={{ background: '#000', color: '#fff', padding: '1em' }}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3220,6 +3220,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cors": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
+      "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "cosmiconfig": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
@@ -9011,9 +9020,9 @@
           }
         },
         "colors": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
-          "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg=="
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
+          "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw=="
         },
         "connect": {
           "version": "3.5.1",
@@ -9024,15 +9033,6 @@
             "finalhandler": "0.5.1",
             "parseurl": "~1.3.1",
             "utils-merge": "1.0.0"
-          }
-        },
-        "cors": {
-          "version": "2.8.4",
-          "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
-          "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
-          "requires": {
-            "object-assign": "^4",
-            "vary": "^1"
           }
         },
         "debug": {
@@ -9086,19 +9086,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        },
-        "opn": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
-          "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
-          "requires": {
-            "is-wsl": "^1.1.0"
-          }
-        },
-        "proxy-middleware": {
-          "version": "0.15.0",
-          "resolved": "https://registry.npmjs.org/proxy-middleware/-/proxy-middleware-0.15.0.tgz",
-          "integrity": "sha1-o/3xvvtzD5UZZYcqwvYHTGFHelY="
         },
         "send": {
           "version": "0.16.2",
@@ -10709,6 +10696,14 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "opn": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+      "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+      "requires": {
+        "is-wsl": "^1.1.0"
+      }
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -11501,6 +11496,11 @@
       "requires": {
         "levenshtein-edit-distance": "^1.0.0"
       }
+    },
+    "proxy-middleware": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/proxy-middleware/-/proxy-middleware-0.15.0.tgz",
+      "integrity": "sha1-o/3xvvtzD5UZZYcqwvYHTGFHelY="
     },
     "prr": {
       "version": "0.0.0",

--- a/src/node/get-postcss-plugins.js
+++ b/src/node/get-postcss-plugins.js
@@ -14,7 +14,10 @@ function getPostcssPlugins(
     postcssUrl({
       url: 'copy',
       assetsPath: './',
-      useHash: true
+      useHash: true,
+      hashOptions: {
+        append: true
+      }
     }),
     // Rewrite urls so they are root-relative. This way they'll work both from
     // inlined CSS (in the static build) and the stylesheet itself.

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -1,6 +1,8 @@
 // @flow
 'use strict';
 
+const webpack = require('webpack');
+
 // This file will be copied into dist/, so these types will serve as the type
 // definition of the public API for Flow-using users.
 type BatfishStart = (
@@ -28,5 +30,6 @@ module.exports = {
   start: (require('./start'): BatfishStart),
   build: (require('./build'): BatfishBuild),
   serveStatic: (require('./serve-static'): BatfishServeStatic),
-  writeBabelrc: (require('./write-babelrc'): BatfishWriteBabelrc)
+  writeBabelrc: (require('./write-babelrc'): BatfishWriteBabelrc),
+  webpack
 };

--- a/test/__snapshots__/compile-stylesheets.test.js.snap
+++ b/test/__snapshots__/compile-stylesheets.test.js.snap
@@ -8,10 +8,10 @@ exports[`compileStylesheets minimizes in production 1`] = `
       }
       .mock-style { color: brown; }
     
-@font-face{font-family:'a';src:url(/mock/base/path/assets/994d9585.woff2) format('woff2')}.a{color:pink}
+@font-face{font-family:'a';src:url(/mock/base/path/assets/a_994d9585.woff2) format('woff2')}.a{color:pink}
 .b{color:orange}
-@font-face{font-family:'c';src:url(/mock/base/path/assets/675d172a.woff2) format('woff2')}.c{color:purple}
-@font-face{font-family:'e';src:url(/mock/base/path/assets/24153b0b.woff2) format('woff2')}.e{color:gray}/*# sourceMappingURL=batfish-styles-66ad6657a4c292a4e6dae6e2afc5bebb.css.map */"
+@font-face{font-family:'c';src:url(/mock/base/path/assets/c_675d172a.woff2) format('woff2')}.c{color:purple}
+@font-face{font-family:'e';src:url(/mock/base/path/assets/e_24153b0b.woff2) format('woff2')}.e{color:gray}/*# sourceMappingURL=batfish-styles-8ca264391785d90b2c9c63b3c7833092.css.map */"
 `;
 
 exports[`compileStylesheets writes expected CSS file 1`] = `
@@ -24,7 +24,7 @@ exports[`compileStylesheets writes expected CSS file 1`] = `
     
 @font-face {
   font-family: 'a';
-  src: url('/mock/base/path/assets/994d9585.woff2') format('woff2');
+  src: url('/mock/base/path/assets/a_994d9585.woff2') format('woff2');
 }
 
 .a { color: pink; }
@@ -33,14 +33,14 @@ exports[`compileStylesheets writes expected CSS file 1`] = `
 
 @font-face {
   font-family: 'c';
-  src: url('/mock/base/path/assets/675d172a.woff2') format('woff2');
+  src: url('/mock/base/path/assets/c_675d172a.woff2') format('woff2');
 }
 
 .c { color: purple; }
 
 @font-face {
   font-family: 'e';
-  src: url('/mock/base/path/assets/24153b0b.woff2') format('woff2');
+  src: url('/mock/base/path/assets/e_24153b0b.woff2') format('woff2');
 }
 
 .e { color: grey; }

--- a/test/compile-stylesheets.test.js
+++ b/test/compile-stylesheets.test.js
@@ -28,7 +28,9 @@ describe('compileStylesheets', () => {
     `;
     got.mockImplementation(arg => {
       if (arg === 'https://www.mapbox.com/mock-style.css') {
-        return Promise.resolve({ body: mockUrlCss });
+        return Promise.resolve({
+          body: mockUrlCss
+        });
       }
       return Promise.reject(new Error('Unexpected URL.'));
     });
@@ -51,7 +53,9 @@ describe('compileStylesheets', () => {
   });
 
   afterEach(() => {
-    return del(tmp, { force: true });
+    return del(tmp, {
+      force: true
+    });
   });
 
   test('writes expected CSS file', () => {
@@ -73,11 +77,11 @@ describe('compileStylesheets', () => {
       expect(fs.readdirSync(tmp)).toEqual([
         // Hashes of these woff2 files are based on the text content, so
         // should stay constant between tests.
-        '24153b0b.woff2',
-        '675d172a.woff2',
-        '994d9585.woff2',
+        'a_994d9585.woff2',
         'batfish-styles.css',
-        'batfish-styles.css.map'
+        'batfish-styles.css.map',
+        'c_675d172a.woff2',
+        'e_24153b0b.woff2'
       ]);
     });
   });


### PR DESCRIPTION
Changelog entries:

- Feature: Files reference as URLs in CSS then copied into the output directory (via postcss-url) now include the file's original basename as well as the hash.
- Feature: Expose Batfish's version of Webpack on `require('@mapbox/batfish').webpack`, so it can be used for custom plugin configuration.

That second item closes #278. I did not end up putting `webpack` into the config function's arguments because I realized that that would make it unavailable to the Node API. Probably nobody uses the Node API — but I wanted to save that discussion for another day.

@kepta once I get the green light here I'll merge and cut a release, which will include your recent improvements.