### PR TITLE
Adding some notes on using async/await

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -439,7 +439,7 @@ Default: `[]`.
 
 By default, all packages installed by npm are excluded from Babel compilation (see [`babelExclude`]).
 If, however, you use a library that includes ES2015+ but does not get compiled for publication (e.g. any of the [promise-fun](https://github.com/sindresorhus/promise-fun) modules), then you'll need to pass that module through Babel.
-That's what this option is for.
+That's what this option is for. If you want to use `await`/`async`, you will can use [babel-polyfill](https://www.npmjs.com/package/babel-polyfill) in [`babelPlugins`](#babelPlugins) or edit the [browser targets](https://stackoverflow.com/a/41331284) in [`babelPresetEnvOptions`](#babelPresetEnvOptions).
 
 The easiest way to include an npm package in your compilation is to pass its name as a string.
 


### PR DESCRIPTION
Went a bit of a 🐰🕳️ yesterday and some issues with `componentDidMount()` with using async/await.

I resolved my issue with using `babel-polyfill` and importing that file wherever I use that code style. However, as this [SO answer states](https://stackoverflow.com/a/41331284), you can use the `babel-preset-env` options for target browsers:

```json
{
  "presets": [
    ["env", {
      "targets": {
        "browsers": ["last 2 Chrome versions"]
      }
    }]
  ]
}
```

I didn't really like this method as much but just wanted to share the knowledge around.

I placed this comment in `babelInclude`, because this is where it's contextually talks about ES2015+ syntax and where I ended up first when I was debugging. Feel free to suggest elsewhere.

cc @mapbox/frontend-platform 