### PR TITLE
increase maxAsyncRequests and maxInitialRequests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Master
+
+- **Fix:** Increase `maxAsyncRequests` and `maxInitialRequests` in `splitChunks` to prevent JavaScript from running out of memory.
+
 ## 1.11.0
 
 - **Fix:** Prevent temporary build files from being written to the output directory.

--- a/src/node/create-webpack-config-client.js
+++ b/src/node/create-webpack-config-client.js
@@ -123,6 +123,8 @@ function createWebpackConfigClient(
           name: 'manifest'
         },
         splitChunks: {
+          maxInitialRequests: 10,
+          maxAsyncRequests: 10,
           cacheGroups: {
             vendor: {
               chunks: 'initial',

--- a/test/__snapshots__/create-webpack-config-client.test.js.snap
+++ b/test/__snapshots__/create-webpack-config-client.test.js.snap
@@ -39,6 +39,8 @@ Object {
           "test": "vendor",
         },
       },
+      "maxAsyncRequests": 10,
+      "maxInitialRequests": 10,
     },
   },
   "output": Object {
@@ -114,6 +116,8 @@ Object {
           "test": "vendor",
         },
       },
+      "maxAsyncRequests": 10,
+      "maxInitialRequests": 10,
     },
   },
   "output": Object {
@@ -192,6 +196,8 @@ Object {
           "test": "vendor",
         },
       },
+      "maxAsyncRequests": 10,
+      "maxInitialRequests": 10,
     },
   },
   "output": Object {


### PR DESCRIPTION
While rolling out Webpack 4 in Batfish, we hit a stopping point with mapbox-gl-js-docs where JavaScript would run out of memory on `build`.

* We fixed one problem where the site was burning memory to generate the stats.json file. #307 
* The build script appears to fail at the terser plugin (minification) because the chunks are too large. This PR attempts to fix that by increasing `maxInitialRequests` and `maxAsyncRequests` to 10 - this will create more chunks at manageable size.
  - https://engineering.wingify.com/posts/demystifying-split-chunks-plugin/
  - https://engineering.seagroup.com/shopee-webpack4/

Testing to do:

* [x] mapbox-gl-js-docs, start and build/serve-static
* [x] android-docs, start and build/serve-static
* [x] traffic-data-docs, start and build/serve-static
* [x] open built site in IE11
* [x] test examples/