### PR TITLE
Revert #317 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- **Fix**: Revert increase `maxAsyncRequests` and `maxInitialRequests` in `splitChunks` to prevent JavaScript from running out of memory.
+
 ## 1.11.1
 
 - **Fix:** Increase `maxAsyncRequests` and `maxInitialRequests` in `splitChunks` to prevent JavaScript from running out of memory.

--- a/src/node/create-webpack-config-client.js
+++ b/src/node/create-webpack-config-client.js
@@ -123,8 +123,6 @@ function createWebpackConfigClient(
           name: 'manifest'
         },
         splitChunks: {
-          maxInitialRequests: 10,
-          maxAsyncRequests: 10,
           cacheGroups: {
             vendor: {
               chunks: 'initial',

--- a/test/__snapshots__/create-webpack-config-client.test.js.snap
+++ b/test/__snapshots__/create-webpack-config-client.test.js.snap
@@ -39,8 +39,6 @@ Object {
           "test": "vendor",
         },
       },
-      "maxAsyncRequests": 10,
-      "maxInitialRequests": 10,
     },
   },
   "output": Object {
@@ -116,8 +114,6 @@ Object {
           "test": "vendor",
         },
       },
-      "maxAsyncRequests": 10,
-      "maxInitialRequests": 10,
     },
   },
   "output": Object {
@@ -196,8 +192,6 @@ Object {
           "test": "vendor",
         },
       },
-      "maxAsyncRequests": 10,
-      "maxInitialRequests": 10,
     },
   },
   "output": Object {


### PR DESCRIPTION
Per https://github.com/mapbox/batfish/pull/317#discussion_r323396653 the previous commit and release which increased `maxAsyncRequests` and `maxInitialRequests` in `splitChunks` to prevent JavaScript from running out of memory is not an ideal long term solution as it deteriorates performance on older devices. 

This PR reverts that commit. We'll be looking for a better solution that will not affect build times on the client and prevent running out of memory on `build`. 

In the meantime, we can increase node's memory with:

```
 "build": "NODE_OPTIONS=--max-old-space-size=2048 batfish build"
```