### PR TITLE
Add option to ignore files from being added to the sitemap

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -538,11 +538,30 @@ Each item is an object with the following properties:
 
 ### sitemap
 
-Type: `boolean`.
+Type: `boolean` or `object`.
 Default: `true`.
 
 By default, if you have set [`siteOrigin`] a `sitemap.xml` file will be generated and placed in your [`outputDirectory`] during `batfish build`.
-Set this to `false` to skip this step if you do not want a sitemap.
+
+- Set this to `false` to skip this step if you do not want a sitemap.
+- To exclude files or a directory from the sitemap, set `sitemap` to:
+
+```json
+sitemap: {
+  ignoreFile: 'path/to-ignore-file.js'
+}
+```
+
+The value of `ignoreFile` is the pathname to a JavaScript file. The JavaScript file must export an array of file paths or directories that you do not want Batfish to include in the sitemap. Each path must include the [`outputDirectory`]. 
+
+Example:
+
+```js
+module.exports = [
+  `${process.cwd()}/_batfish_site/assets/`,
+  `${process.cwd()}/_batfish_site/demo/simple-map.html`
+];
+```
 
 ### production
 

--- a/examples/sitemap/README.md
+++ b/examples/sitemap/README.md
@@ -1,0 +1,9 @@
+# Customize the sitemap
+
+This example customizes the sitemap by using the `ignoreFile` option to remove files from appearing in the sitemap.
+
+Since Batfish only generates the sitemap on build, run:
+
+```
+npm run batfish -- build && npm run batfish -- serve-static
+```

--- a/examples/sitemap/README.md
+++ b/examples/sitemap/README.md
@@ -1,6 +1,6 @@
 # Customize the sitemap
 
-This example customizes the sitemap by using the `ignoreFile` option to remove files from appearing in the sitemap.
+This example customizes the sitemap by using the `ignoreFile` option to remove some files from the sitemap.
 
 Since Batfish only generates the sitemap on build, run:
 

--- a/examples/sitemap/batfish.config.js
+++ b/examples/sitemap/batfish.config.js
@@ -1,0 +1,25 @@
+module.exports = () => {
+  return {
+    siteOrigin: 'https://www.batfish-basic.com',
+    webpackLoaders: [
+      {
+        test: /\.html$/,
+        /* simulates a process where an html file is transformed and then saved to assets folder */
+        use: [
+          'file-loader?name=[name]-demo.[ext]',
+          'extract-loader',
+          {
+            loader: 'html-loader',
+            options: {
+              minimize: true
+            }
+          }
+        ]
+      }
+    ],
+    ignoreWithinPagesDirectory: ['example/*.html'],
+    sitemap: {
+      ignoreFile: 'ignore.js'
+    }
+  };
+};

--- a/examples/sitemap/ignore.js
+++ b/examples/sitemap/ignore.js
@@ -1,0 +1,1 @@
+module.exports = [`${process.cwd()}/_batfish_site/assets/`];

--- a/examples/sitemap/ignore.js
+++ b/examples/sitemap/ignore.js
@@ -1,1 +1,3 @@
-module.exports = [`${process.cwd()}/_batfish_site/assets/`];
+module.exports = [
+  `${process.cwd()}/_batfish_site/assets/` // prevent any pages from the assets folder from being added to the sitemap
+];

--- a/examples/sitemap/package.json
+++ b/examples/sitemap/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "scripts": {
+    "batfish": "../../bin/example-batfish"
+  },
+  "dependencies": {
+    "extract-loader": "^5.1.0",
+    "html-loader": "^1.3.2"
+  }
+}

--- a/examples/sitemap/src/pages/example/simple-map.html
+++ b/examples/sitemap/src/pages/example/simple-map.html
@@ -1,0 +1,1 @@
+<p>I am a code demo that should not be indexed by web crawlers!</p>

--- a/examples/sitemap/src/pages/index.js
+++ b/examples/sitemap/src/pages/index.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import iframe from './example/simple-map.html';
+export default class Home extends React.PureComponent {
+  render() {
+    return (
+      <div>
+        <h1>Sitemap demo</h1>
+        <p>
+          The url{' '}
+          <code>
+            https://www.batfish-basic.com{iframe.replace('.html', '')}
+          </code>{' '}
+          should not appear in the <a href="/sitemap.xml">sitemap</a>.
+        </p>
+        <iframe src={iframe} title="Simple map" />
+      </div>
+    );
+  }
+}

--- a/flow-typed/defs.js
+++ b/flow-typed/defs.js
@@ -55,7 +55,9 @@ declare type BatfishConfiguration = {
   port: number,
   verbose: boolean,
   spa: boolean,
-  sitemap: boolean,
+  sitemap: boolean | {
+    ignoreFile?: string
+  },
   pageSpecificCss: boolean,
   staticHtmlInlineDeferCss: boolean
 };

--- a/src/node/generate-sitemap.js
+++ b/src/node/generate-sitemap.js
@@ -22,7 +22,8 @@ function generateSitemap(batfishConfig: BatfishConfiguration): Promise<void> {
         String(batfishConfig.siteBasePath),
         ''
       ),
-      pretty: true
+      pretty: true,
+      ignoreFile: batfishConfig.sitemap.ignoreFile || ''
     });
   });
 }

--- a/src/node/validate-config.js
+++ b/src/node/validate-config.js
@@ -193,8 +193,8 @@ const configSchema = {
     description: 'boolean'
   },
   sitemap: {
-    validator: _.isBoolean,
-    description: 'boolean'
+    validator: (x) => _.isBoolean(x) || _.isPlainObject(x),
+    description: 'boolean or object'
   },
   webpackStats: {
     validator: _.isBoolean,


### PR DESCRIPTION
There are times when we do not want Batfish (via sitemap-static) to add a file or a directory to the sitemap. This PR will enable sitemap exclusions:

- Updates the `sitemap` option in the Batfish config to accept an object, in addition to boolean. 
  - The new `sitemap` object accepts the `ignoreFile` option as defined by sitemap-static: https://www.npmjs.com/package/sitemap-static#ignore-file
  - I don't think there are any other sitemap-static options that we want to pass through at this time.
- Adds an example site to demo the feature in use.


## How to test

- [ ] Try the example at `examples/basic`. Run `npm run batfish -- build && npm run batfish -- serve-static` and then open the sitemap to make sure all files are accounted for.
- [ ] Try the example at `examples/sitemap`. Run `npm run batfish -- build && npm run batfish -- serve-static` and then open the sitemap to make sure that there are no files from the `assets` folder.

@danswick for review 