### PR TITLE
Check if path ending in index.html has an extensionless route

### DIFF
--- a/src/webpack/find-matching-route.js
+++ b/src/webpack/find-matching-route.js
@@ -10,8 +10,9 @@ function createPathRegExps(
     // Pages with internal routing aren't just exact matches.
     const ending = route.internalRouting ? '(/.+)?$' : '$';
     // ? because the last slash is optional
+    // and check if `index.html` has an extensionless route
     result[route.path] = new RegExp(
-      `^${route.path.replace(/\//g, '[/]')}?${ending}`
+      `^${route.path.replace(/\//g, '[/]')}?(index.html)?${ending}`
     );
     return result;
   }, {});

--- a/test/find-matching-route.test.js
+++ b/test/find-matching-route.test.js
@@ -50,6 +50,10 @@ describe('findMatchingRoute', () => {
     expect(findMatchingRoute('/foo/')).toBe(batfishContext.routes[0]);
   });
 
+  test('input ends in index.html', () => {
+    expect(findMatchingRoute('/foo/index.html')).toBe(batfishContext.routes[0]);
+  });
+
   test('input lacks trailing slash', () => {
     expect(findMatchingRoute('/foo/bar')).toBe(batfishContext.routes[1]);
   });


### PR DESCRIPTION
If a site does not have a `404.md` or `404.js` in its pages directory and you add `index.html` to the path, the page will fail:

```
Uncaught Error: No matching route.
    at Object.getPage (batfish-context.js:2124)
    at Module.3Rqx (render-batfish-app.js:13)
    at f (index.html:10)
    at Object.0 (app-251eb8da68c307965002.chunk.js:1)
    at f (index.html:10)
    at c (index.html:10)
    at Array.e [as push] (index.html:10)
    at app-251eb8da68c307965002.chunk.js:1
```

Example url: https://docs.mapbox.com/help/index.html

Since `getPage` throws an error, we cannot collect analytics or Sentry issues to understand the scope of the problem.

Given that it's widely assumed that `/` is the same as `/index.html`, this PR checks for `index.html` paths to see if it has a matching extensionless route.

