### PR TITLE
Skip urls that begin with `%23clip` in postcss-absolute-urls

### DIFF
--- a/src/node/postcss-absolute-urls.js
+++ b/src/node/postcss-absolute-urls.js
@@ -8,7 +8,7 @@ const postcssUrl = require('postcss-url');
 // PostCSS plugin that transforms all the URLs in some CSS to absolute URLs.
 function postcssAbsoluteUrls(options: { stylesheetUrl: string }): Function {
   const transformUrl = (originalUrl: string): string => {
-    if (/^data:/.test(originalUrl)) return originalUrl;
+    if (/^data:|^%23clip/.test(originalUrl)) return originalUrl;
     return url.resolve(options.stylesheetUrl, originalUrl);
   };
 

--- a/test/__snapshots__/postcss-absolute-urls.test.js.snap
+++ b/test/__snapshots__/postcss-absolute-urls.test.js.snap
@@ -10,7 +10,7 @@ exports[`postcssAbsoluteUrls do not add absolute url to \`mask\` 1`] = `
       background-repeat: no-repeat;
       cursor: pointer;
       overflow: hidden;
-      background-image: url(\\"data:image/svg+xml;charset=utf-8,%3Csvg mask='url(/playground/assets/%23clip)'\\");
+      background-image: url(\\"data:image/svg+xml;charset=utf-8,%3Csvg mask='url(%23clip)'\\");
     }    
     "
 `;

--- a/test/__snapshots__/postcss-absolute-urls.test.js.snap
+++ b/test/__snapshots__/postcss-absolute-urls.test.js.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`postcssAbsoluteUrls do not add absolute url to \`mask\` 1`] = `
+"
+    a.mapboxgl-ctrl-logo {
+      width: 88px;
+      height: 23px;
+      margin: 0 0 -4px -4px;
+      display: block;
+      background-repeat: no-repeat;
+      cursor: pointer;
+      overflow: hidden;
+      background-image: url(\\"data:image/svg+xml;charset=utf-8,%3Csvg mask='url(/playground/assets/%23clip)'\\");
+    }    
+    "
+`;
+
 exports[`postcssAbsoluteUrls works 1`] = `
 "
       @font-face {

--- a/test/postcss-absolute-urls.test.js
+++ b/test/postcss-absolute-urls.test.js
@@ -27,4 +27,30 @@ describe('postcssAbsoluteUrls', () => {
         expect(result.css).toMatchSnapshot();
       });
   });
+
+  test('do not add absolute url to `mask`', () => {
+    const css = `
+    a.mapboxgl-ctrl-logo {
+      width: 88px;
+      height: 23px;
+      margin: 0 0 -4px -4px;
+      display: block;
+      background-repeat: no-repeat;
+      cursor: pointer;
+      overflow: hidden;
+      background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg mask='url(%23clip)'");
+    }    
+    `;
+
+    return postcss()
+      .use(
+        postcssAbsoluteUrls({
+          stylesheetUrl: '/playground/assets/'
+        })
+      )
+      .process(css, { from: undefined })
+      .then((result) => {
+        expect(result.css).toMatchSnapshot();
+      });
+  });
 });


### PR DESCRIPTION
We found a bug where the Mapbox logo in Firefox appears warped:

![image](https://user-images.githubusercontent.com/2180540/142279236-d7012d71-6485-4f08-b977-230c00ed6092.png)

This is caused by postcss-absolute-urls appending the stylesheet url to `mask`. This PR will prevent the plugin from add an absolute url path to urls that begin with `%23clip`.

To see the bug in action, check out the snapshot in 9f829ca and then see how it removes the absolute url from `mask` in the snapshot: 6a9db10