### PR TITLE
Remove node_js version from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: node_js
-node_js:
-  - 10
-  - 12
 cache: false
 before_install:
   - npm i -g npm@latest


### PR DESCRIPTION
Since this repository defines `.nvmrc`, we do not also need to define `node_js` in travis.yml.