### PR TITLE
Fix config file typo in CLI app and docs/cli

### DIFF
--- a/bin/batfish.js
+++ b/bin/batfish.js
@@ -27,7 +27,7 @@ ${chalk.bold('Usage')}
   batfish <command> [options]
 
   You must provide a batfish configuration module, either with
-  batish.config.js in process.cwd() or with the --config option.
+  batfish.config.js in process.cwd() or with the --config option.
 
 ${chalk.bold('Commands')}
   start            Start a development server.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,7 +9,7 @@ Usage
   batfish <command> [options]
 
   You must provide a batfish configuration module, either with
-  batish.config.js in process.cwd() or with the --config option.
+  batfish.config.js in process.cwd() or with the --config option.
 
 Commands
   start            Start a development server.


### PR DESCRIPTION
`batish.config.js` -> `batfish.config.js`

Hello! I found this repo while applying to Mapbox, and decided to give it a shot. 

I noticed this typo the first time I spun up the CLI, so I did a ripgrep to see if it occurs anywhere else before fixing all instances to make this PR.