### PR TITLE
remove stray console log

### DIFF
--- a/src/node/generate-sitemap.js
+++ b/src/node/generate-sitemap.js
@@ -8,7 +8,6 @@ const joinUrlParts = require('./join-url-parts');
 
 // Build a sitemap cataloging the HTML files in the outputDirectory.
 function generateSitemap(batfishConfig: BatfishConfiguration): Promise<void> {
-  console.log('hello foo')
   const sitemapWriter = fs.createWriteStream(
     path.join(batfishConfig.outputDirectory, 'sitemap.xml')
   );


### PR DESCRIPTION
Removes a stray console.log() 
that was added in 
2f0c48bedb35066cd58df66366d3383f6a46c657
