### PR TITLE
Allow object postcss plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/batfish",
-  "version": "2.4.3",
+  "version": "2.4.4-dev1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/batfish",
-      "version": "2.4.3",
+      "version": "2.4.4-dev1",
       "license": "ISC",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/batfish",
-  "version": "2.4.3",
+  "version": "2.4.4-dev1",
   "description": "The React-powered static-site generator you didn't know you wanted",
   "main": "dist/node/index.js",
   "bin": {

--- a/src/node/validate-config.js
+++ b/src/node/validate-config.js
@@ -115,8 +115,8 @@ const configSchema = {
     validator: _.isArray
   },
   postcssPlugins: {
-    validator: (x) => _.isFunction(x) || isArrayOf(_.isFunction)(x),
-    description: 'function or array of functions'
+    validator: (x) => _.isFunction(x) || isArrayOf(_.isFunction)(x) || _.isPlainObject(x),
+    description: 'function or array of functions or object'
   },
   fileLoaderExtensions: {
     validator: (x) => isArrayOf(_.isString)(x) || _.isFunction(x),


### PR DESCRIPTION
New Post CSS plugins come as objects rather than plugins. Since we already have postcss 8 support, these should work by just allowing objects as well as functions when validating the input

TODO: Probably better validation for the input schema of the objects